### PR TITLE
Add complexity benchmarks

### DIFF
--- a/benches/linear.rs
+++ b/benches/linear.rs
@@ -1,0 +1,48 @@
+#![feature(test)]
+
+// The benchmarks here verify that the complexity grows as O(*n*)
+// where *n* is the size of the text to be wrapped.
+
+extern crate test;
+extern crate textwrap;
+
+use test::Bencher;
+
+fn lorem_ipsum(length: usize) -> &'static str {
+    let text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas feugiat non mi \
+                rutrum consectetur. Nulla iaculis luctus ex suscipit posuere. Sed et tellus quis \
+                elit volutpat pretium. Sed faucibus purus vitae feugiat tincidunt. Nulla \
+                malesuada interdum tempus. Proin consectetur malesuada magna, id suscipit enim \
+                tempus in. Sed sollicitudin velit tortor, quis condimentum nisl vulputate \
+                lobortis. Curabitur id lectus arcu. Nullam quis aliquam nisi. Vestibulum quam \
+                enim, elementum vel urna scelerisque, ultricies cursus urna. Mauris vestibulum, \
+                augue non posuere viverra, risus tortor iaculis augue, eget convallis metus nisl \
+                vestibulum nisi. Aenean auctor dui vel aliquet sagittis. Aliquam quis enim \
+                mauris. Nunc eu leo et orci euismod bibendum vel eu tortor. Nam egestas volutpat \
+                ex, a turpis duis.";
+    text.split_at(length).0
+}
+
+#[bench]
+fn lorem_100(b: &mut Bencher) {
+    let text = lorem_ipsum(100);
+    b.iter(|| textwrap::fill(text, 60))
+}
+
+#[bench]
+fn lorem_200(b: &mut Bencher) {
+    let text = lorem_ipsum(200);
+    b.iter(|| textwrap::fill(text, 60))
+}
+
+#[bench]
+fn lorem_400(b: &mut Bencher) {
+    let text = lorem_ipsum(400);
+    b.iter(|| textwrap::fill(text, 60))
+}
+
+#[bench]
+fn lorem_800(b: &mut Bencher) {
+    let text = lorem_ipsum(800);
+    b.iter(|| textwrap::fill(text, 60))
+}

--- a/benches/linear.rs
+++ b/benches/linear.rs
@@ -11,6 +11,8 @@ use test::Bencher;
 use hyphenation::Language;
 use textwrap::Wrapper;
 
+const LINE_LENGTH: usize = 60;
+
 fn lorem_ipsum(length: usize) -> &'static str {
     let text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas feugiat non mi \
                 rutrum consectetur. Nulla iaculis luctus ex suscipit posuere. Sed et tellus quis \
@@ -29,32 +31,32 @@ fn lorem_ipsum(length: usize) -> &'static str {
 #[bench]
 fn lorem_100(b: &mut Bencher) {
     let text = lorem_ipsum(100);
-    b.iter(|| textwrap::fill(text, 60))
+    b.iter(|| textwrap::fill(text, LINE_LENGTH))
 }
 
 #[bench]
 fn lorem_200(b: &mut Bencher) {
     let text = lorem_ipsum(200);
-    b.iter(|| textwrap::fill(text, 60))
+    b.iter(|| textwrap::fill(text, LINE_LENGTH))
 }
 
 #[bench]
 fn lorem_400(b: &mut Bencher) {
     let text = lorem_ipsum(400);
-    b.iter(|| textwrap::fill(text, 60))
+    b.iter(|| textwrap::fill(text, LINE_LENGTH))
 }
 
 #[bench]
 fn lorem_800(b: &mut Bencher) {
     let text = lorem_ipsum(800);
-    b.iter(|| textwrap::fill(text, 60))
+    b.iter(|| textwrap::fill(text, LINE_LENGTH))
 }
 
 #[bench]
 fn hyphenation_lorem_100(b: &mut Bencher) {
     let text = lorem_ipsum(100);
     let corpus = hyphenation::load(Language::Latin).unwrap();
-    let mut wrapper = Wrapper::new(60);
+    let mut wrapper = Wrapper::new(LINE_LENGTH);
     wrapper.corpus = Some(&corpus);
 
     b.iter(|| wrapper.fill(text))
@@ -64,7 +66,7 @@ fn hyphenation_lorem_100(b: &mut Bencher) {
 fn hyphenation_lorem_200(b: &mut Bencher) {
     let text = lorem_ipsum(200);
     let corpus = hyphenation::load(Language::Latin).unwrap();
-    let mut wrapper = Wrapper::new(60);
+    let mut wrapper = Wrapper::new(LINE_LENGTH);
     wrapper.corpus = Some(&corpus);
 
     b.iter(|| wrapper.fill(text))
@@ -74,7 +76,7 @@ fn hyphenation_lorem_200(b: &mut Bencher) {
 fn hyphenation_lorem_400(b: &mut Bencher) {
     let text = lorem_ipsum(400);
     let corpus = hyphenation::load(Language::Latin).unwrap();
-    let mut wrapper = Wrapper::new(60);
+    let mut wrapper = Wrapper::new(LINE_LENGTH);
     wrapper.corpus = Some(&corpus);
 
     b.iter(|| wrapper.fill(text))
@@ -84,7 +86,7 @@ fn hyphenation_lorem_400(b: &mut Bencher) {
 fn hyphenation_lorem_800(b: &mut Bencher) {
     let text = lorem_ipsum(800);
     let corpus = hyphenation::load(Language::Latin).unwrap();
-    let mut wrapper = Wrapper::new(60);
+    let mut wrapper = Wrapper::new(LINE_LENGTH);
     wrapper.corpus = Some(&corpus);
 
     b.iter(|| wrapper.fill(text))

--- a/benches/linear.rs
+++ b/benches/linear.rs
@@ -4,9 +4,12 @@
 // where *n* is the size of the text to be wrapped.
 
 extern crate test;
+extern crate hyphenation;
 extern crate textwrap;
 
 use test::Bencher;
+use hyphenation::Language;
+use textwrap::Wrapper;
 
 fn lorem_ipsum(length: usize) -> &'static str {
     let text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas feugiat non mi \
@@ -45,4 +48,44 @@ fn lorem_400(b: &mut Bencher) {
 fn lorem_800(b: &mut Bencher) {
     let text = lorem_ipsum(800);
     b.iter(|| textwrap::fill(text, 60))
+}
+
+#[bench]
+fn hyphenation_lorem_100(b: &mut Bencher) {
+    let text = lorem_ipsum(100);
+    let corpus = hyphenation::load(Language::Latin).unwrap();
+    let mut wrapper = Wrapper::new(60);
+    wrapper.corpus = Some(&corpus);
+
+    b.iter(|| wrapper.fill(text))
+}
+
+#[bench]
+fn hyphenation_lorem_200(b: &mut Bencher) {
+    let text = lorem_ipsum(200);
+    let corpus = hyphenation::load(Language::Latin).unwrap();
+    let mut wrapper = Wrapper::new(60);
+    wrapper.corpus = Some(&corpus);
+
+    b.iter(|| wrapper.fill(text))
+}
+
+#[bench]
+fn hyphenation_lorem_400(b: &mut Bencher) {
+    let text = lorem_ipsum(400);
+    let corpus = hyphenation::load(Language::Latin).unwrap();
+    let mut wrapper = Wrapper::new(60);
+    wrapper.corpus = Some(&corpus);
+
+    b.iter(|| wrapper.fill(text))
+}
+
+#[bench]
+fn hyphenation_lorem_800(b: &mut Bencher) {
+    let text = lorem_ipsum(800);
+    let corpus = hyphenation::load(Language::Latin).unwrap();
+    let mut wrapper = Wrapper::new(60);
+    wrapper.corpus = Some(&corpus);
+
+    b.iter(|| wrapper.fill(text))
 }


### PR DESCRIPTION
These benchmarks wrap longer and longer texts and the goal is to get
numbers that can verify that the time grows as O(n) where n is the
size of the input text.

When running the benchmarks, the output looks like this on my machine:

    test lorem_100             ... bench:       2,085 ns/iter (+/- 11)
    test lorem_200             ... bench:       4,223 ns/iter (+/- 23)
    test lorem_400             ... bench:       8,331 ns/iter (+/- 36)
    test lorem_800             ... bench:      17,182 ns/iter (+/- 86)

That looks more or less like a linear growth.
