### PR TITLE
wrap: estimate number of necessary lines for result

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,7 @@ impl<'a> Wrapper<'a> {
     /// an O(*n*) time and memory complexity where *n* is the input
     /// string length.
     pub fn wrap(&self, s: &str) -> Vec<String> {
-        let mut result = Vec::new();
+        let mut result = Vec::with_capacity(s.len() / (self.width + 1));
         let mut line = String::with_capacity(self.width);
         let mut remaining = self.width;
 


### PR DESCRIPTION
This seems to lead to a small speedup some of the time:

    name                   before ns/iter  after ns/iter  diff ns/iter  diff %
    hyphenation_lorem_100  4,345           4,250                   -95  -2.19%
    hyphenation_lorem_200  8,180           8,009                  -171  -2.09%
    hyphenation_lorem_400  17,348          16,566                 -782  -4.51%
    hyphenation_lorem_800  39,018          36,795               -2,223  -5.70%
    lorem_100              2,089           2,034                   -55  -2.63%
    lorem_200              4,216           4,053                  -163  -3.87%
    lorem_400              8,343           7,886                  -457  -5.48%
    lorem_800              16,823          15,953                 -870  -5.17%

However, I also had before/after results where there was a 1-2% decrease in speed for the tests that have enabled automatic hyphenation. Overall, though, this ought to be a correct optimization.