### PR TITLE
Add a fast path for words fitting on the current line

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,6 +101,12 @@ impl<'a> Wrapper<'a> {
         let mut remaining = self.width;
 
         for mut word in s.split_whitespace() {
+            // Attempt to fit the word without any splitting.
+            if self.fit_part(word, "", &mut remaining, &mut line) {
+                continue;
+            }
+
+            // If that failed, loop until nothing remains to be added.
             while !word.is_empty() {
                 let splits = self.split_word(&word);
                 let (smallest, hyphen, longest) = splits[0];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,17 +114,9 @@ impl<'a> Wrapper<'a> {
                     remaining = self.width;
                 }
 
-                let space = if line.is_empty() { 0 } else { 1 };
-
                 // Find a split that fits on the current line.
                 for &(head, hyphen, tail) in splits.iter().rev() {
-                    if space + head.width() + hyphen.len() <= remaining {
-                        if !line.is_empty() {
-                            line.push(' ');
-                        }
-                        line.push_str(head);
-                        line.push_str(hyphen);
-                        remaining -= space + head.width() + hyphen.len();
+                    if self.fit_part(head, hyphen, &mut remaining, &mut line) {
                         word = tail;
                         break;
                     }
@@ -184,6 +176,28 @@ impl<'a> Wrapper<'a> {
         result.push((word, "", ""));
 
         return result;
+    }
+
+    /// Try to fit a word (or part of a word) onto a line. The line
+    /// and the remaining width is updated as appropriate if the word
+    /// or part fits.
+    fn fit_part<'b>(&self,
+                    part: &'b str,
+                    hyphen: &'b str,
+                    remaining: &mut usize,
+                    line: &mut String)
+                    -> bool {
+        let space = if line.is_empty() { 0 } else { 1 };
+        if space + part.width() + hyphen.len() <= *remaining {
+            if !line.is_empty() {
+                line.push(' ');
+            }
+            line.push_str(part);
+            line.push_str(hyphen);
+            *remaining -= space + part.width() + hyphen.len();
+            return true;
+        }
+        return false;
     }
 }
 


### PR DESCRIPTION
This add a fast path where we attempt to add a word directly without any splitting. This cuts the running time by about half:

```
name                   before ns/iter  after ns/iter  diff ns/iter   diff %
hyphenation_lorem_100  4,282           1,485                -2,797  -65.32%
hyphenation_lorem_200  8,073           2,740                -5,333  -66.06%
hyphenation_lorem_400  16,647          5,399               -11,248  -67.57%
hyphenation_lorem_800  37,622          11,741              -25,881  -68.79%
lorem_100              2,004           881                  -1,123  -56.04%
lorem_200              3,995           1,880                -2,115  -52.94%
lorem_400              7,787           3,650                -4,137  -53.13%
lorem_800              15,746          7,395                -8,351  -53.04%
```

Fixes #13.
