### PR TITLE
Break words longer than the line width

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,9 @@ pub struct Wrapper<'a> {
 }
 
 impl<'a> Wrapper<'a> {
-    /// Create a new Wrapper for wrapping at the specified width.
+    /// Create a new Wrapper for wrapping at the specified width. By
+    /// default, we allow words longer than `width` to be broken. No
+    /// hyphenation corpus is loaded by default.
     pub fn new(width: usize) -> Wrapper<'a> {
         Wrapper::<'a> {
             width: width,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,8 +80,8 @@ impl<'a> Wrapper<'a> {
         self.wrap(&s).join("\n")
     }
 
-    /// Wrap  a line of  text at `self.width` characters.  Strings are
-    ///  wrapped based  on their  displayed width,  not their  size in
+    /// Wrap a line of text at `self.width` characters. Strings are
+    /// wrapped based on their displayed width, not their size in
     /// bytes.
     ///
     /// ```


### PR DESCRIPTION
Before, words longer than `self.width` would simply result in overfull lines. We now have a setting to control this behavior.