### PR TITLE
appveyor: show crate versions in build and test steps

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,10 +10,10 @@ install:
   - set PATH=%PATH%;%USERPROFILE%\.cargo\bin
 
 build_script:
-  - cargo build
+  - cargo build --verbose
 
 test_script:
-  - cargo test
+  - cargo test --verbose
 
 cache:
   - '%USERPROFILE%\.cargo'


### PR DESCRIPTION
This makes the command and output match Travis CI and I guess knowing
the exact versions used will be handy one day.