### PR TITLE
appveyor: allow failures with nightly Rust

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,10 @@ environment:
   - TOOLCHAIN: beta
   - TOOLCHAIN: nightly
 
+matrix:
+  allow_failures:
+    - TOOLCHAIN: nightly
+
 install:
   - ps: Start-FileDownload 'https://static.rust-lang.org/rustup/dist/i686-pc-windows-gnu/rustup-init.exe'
   - rustup-init.exe -y --default-toolchain %TOOLCHAIN%


### PR DESCRIPTION
This makes the configuration mirror the Travis CI configuration where
we also allow failures when building with the nightly compiler.