### PR TITLE
split_word: simply use ends_with to get last character

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,11 +197,7 @@ impl<'a> Wrapper<'a> {
                 // the splits that would have been found above.
                 for n in word.opportunities(corpus) {
                     let (head, tail) = word.split_at(n);
-                    let hyphen = if head.as_bytes()[head.len() - 1] == b'-' {
-                        ""
-                    } else {
-                        "-"
-                    };
+                    let hyphen = if head.ends_with('-') { "" } else { "-" };
                     triples.push((head, hyphen, tail));
                 }
             }


### PR DESCRIPTION
Testing shows the performance to be the same or perhaps even
marginally faster.