### PR TITLE
Test minimum Rust version in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: rust
 
 rust:
+  - 1.13.0
   - stable
   - beta
   - nightly

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,6 @@
 environment:
   matrix:
+  - TOOLCHAIN: 1.13.0
   - TOOLCHAIN: stable
   - TOOLCHAIN: beta
   - TOOLCHAIN: nightly


### PR DESCRIPTION
This updates the Travis and AppVeyor configs to test with Rust 1.13.0, which happens to be the earliest version of Rust where all our dependencies compile.