### PR TITLE
Make hyphenation optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,14 @@ rust:
 
 cache: cargo
 
+script:
+  - cargo build --verbose --features "$FEATURES"
+  - cargo test --verbose --features "$FEATURES"
+
+env:
+  - FEATURES="hyphenation"
+  - FEATURES=""
+
 matrix:
   allow_failures:
     - rust: nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ appveyor = { repository = "mgeisler/textwrap" }
 
 [dependencies]
 unicode-width = "0.1.3"
-hyphenation = "0.6.1"
+hyphenation = { version = "0.6.1", optional = true }

--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ and this to your crate root:
 extern crate textwrap;
 ```
 
+If you would like to have automatic hyphenation, specify the
+dependency as:
+```toml
+[dependencies]
+textwrap = { version: "0.4", features: ["hyphenation"] }
+```
+
 ## Documentation
 
 **[API documentation][api-docs]**
@@ -46,8 +53,9 @@ library for
 wrapping text.
 ```
 
-You can use automatic hyphenation using TeX hyphenation patterns (with
-support for [about 70 languages][patterns]) and get:
+With the `hyphenation` feature, you can get automatic hyphenation
+for [about 70 languages][patterns]. Your program must load and
+configure the hyphenation patterns to use:
 ```rust
 extern crate hyphenation;
 extern crate textwrap;
@@ -71,13 +79,15 @@ library for wrap-
 ping text.
 ```
 
+The hyphenation uses high-quality TeX hyphenation patterns.
+
 ## Examples
 
 The library comes with a small example program that shows how a fixed
 example string is wrapped at different widths. Run the example with:
 
 ```shell
-$ cargo run --example layout
+$ cargo run --features hyphenation --example layout
 ```
 
 The program will use the following string:

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ use textwrap::Wrapper;
 fn main() {
     let corpus = hyphenation::load(Language::English_US).unwrap();
     let mut wrapper = Wrapper::new(18);
-    wrapper.corpus = Some(&corpus);
+    wrapper.splitter = Box::new(corpus);
     let text = "textwrap: a small library for wrapping text.";
     println!("{}", wrapper.fill(text))
 }

--- a/benches/linear.rs
+++ b/benches/linear.rs
@@ -57,7 +57,7 @@ fn hyphenation_lorem_100(b: &mut Bencher) {
     let text = lorem_ipsum(100);
     let corpus = hyphenation::load(Language::Latin).unwrap();
     let mut wrapper = Wrapper::new(LINE_LENGTH);
-    wrapper.corpus = Some(&corpus);
+    wrapper.corpus = Some(corpus);
 
     b.iter(|| wrapper.fill(text))
 }
@@ -67,7 +67,7 @@ fn hyphenation_lorem_200(b: &mut Bencher) {
     let text = lorem_ipsum(200);
     let corpus = hyphenation::load(Language::Latin).unwrap();
     let mut wrapper = Wrapper::new(LINE_LENGTH);
-    wrapper.corpus = Some(&corpus);
+    wrapper.corpus = Some(corpus);
 
     b.iter(|| wrapper.fill(text))
 }
@@ -77,7 +77,7 @@ fn hyphenation_lorem_400(b: &mut Bencher) {
     let text = lorem_ipsum(400);
     let corpus = hyphenation::load(Language::Latin).unwrap();
     let mut wrapper = Wrapper::new(LINE_LENGTH);
-    wrapper.corpus = Some(&corpus);
+    wrapper.corpus = Some(corpus);
 
     b.iter(|| wrapper.fill(text))
 }
@@ -87,7 +87,7 @@ fn hyphenation_lorem_800(b: &mut Bencher) {
     let text = lorem_ipsum(800);
     let corpus = hyphenation::load(Language::Latin).unwrap();
     let mut wrapper = Wrapper::new(LINE_LENGTH);
-    wrapper.corpus = Some(&corpus);
+    wrapper.corpus = Some(corpus);
 
     b.iter(|| wrapper.fill(text))
 }

--- a/benches/linear.rs
+++ b/benches/linear.rs
@@ -4,11 +4,14 @@
 // where *n* is the size of the text to be wrapped.
 
 extern crate test;
+#[cfg(feature = "hyphenation")]
 extern crate hyphenation;
 extern crate textwrap;
 
 use test::Bencher;
+#[cfg(feature = "hyphenation")]
 use hyphenation::Language;
+#[cfg(feature = "hyphenation")]
 use textwrap::Wrapper;
 
 const LINE_LENGTH: usize = 60;
@@ -53,6 +56,7 @@ fn lorem_800(b: &mut Bencher) {
 }
 
 #[bench]
+#[cfg(feature = "hyphenation")]
 fn hyphenation_lorem_100(b: &mut Bencher) {
     let text = lorem_ipsum(100);
     let corpus = hyphenation::load(Language::Latin).unwrap();
@@ -63,6 +67,7 @@ fn hyphenation_lorem_100(b: &mut Bencher) {
 }
 
 #[bench]
+#[cfg(feature = "hyphenation")]
 fn hyphenation_lorem_200(b: &mut Bencher) {
     let text = lorem_ipsum(200);
     let corpus = hyphenation::load(Language::Latin).unwrap();
@@ -73,6 +78,7 @@ fn hyphenation_lorem_200(b: &mut Bencher) {
 }
 
 #[bench]
+#[cfg(feature = "hyphenation")]
 fn hyphenation_lorem_400(b: &mut Bencher) {
     let text = lorem_ipsum(400);
     let corpus = hyphenation::load(Language::Latin).unwrap();
@@ -83,6 +89,7 @@ fn hyphenation_lorem_400(b: &mut Bencher) {
 }
 
 #[bench]
+#[cfg(feature = "hyphenation")]
 fn hyphenation_lorem_800(b: &mut Bencher) {
     let text = lorem_ipsum(800);
     let corpus = hyphenation::load(Language::Latin).unwrap();

--- a/benches/linear.rs
+++ b/benches/linear.rs
@@ -57,7 +57,7 @@ fn hyphenation_lorem_100(b: &mut Bencher) {
     let text = lorem_ipsum(100);
     let corpus = hyphenation::load(Language::Latin).unwrap();
     let mut wrapper = Wrapper::new(LINE_LENGTH);
-    wrapper.corpus = Some(corpus);
+    wrapper.splitter = Box::new(corpus);
 
     b.iter(|| wrapper.fill(text))
 }
@@ -67,7 +67,7 @@ fn hyphenation_lorem_200(b: &mut Bencher) {
     let text = lorem_ipsum(200);
     let corpus = hyphenation::load(Language::Latin).unwrap();
     let mut wrapper = Wrapper::new(LINE_LENGTH);
-    wrapper.corpus = Some(corpus);
+    wrapper.splitter = Box::new(corpus);
 
     b.iter(|| wrapper.fill(text))
 }
@@ -77,7 +77,7 @@ fn hyphenation_lorem_400(b: &mut Bencher) {
     let text = lorem_ipsum(400);
     let corpus = hyphenation::load(Language::Latin).unwrap();
     let mut wrapper = Wrapper::new(LINE_LENGTH);
-    wrapper.corpus = Some(corpus);
+    wrapper.splitter = Box::new(corpus);
 
     b.iter(|| wrapper.fill(text))
 }
@@ -87,7 +87,7 @@ fn hyphenation_lorem_800(b: &mut Bencher) {
     let text = lorem_ipsum(800);
     let corpus = hyphenation::load(Language::Latin).unwrap();
     let mut wrapper = Wrapper::new(LINE_LENGTH);
-    wrapper.corpus = Some(corpus);
+    wrapper.splitter = Box::new(corpus);
 
     b.iter(|| wrapper.fill(text))
 }

--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -1,8 +1,23 @@
+#[cfg(feature = "hyphenation")]
 extern crate hyphenation;
 extern crate textwrap;
 
+#[cfg(feature = "hyphenation")]
 use hyphenation::Language;
 use textwrap::Wrapper;
+
+
+#[cfg(not(feature = "hyphenation"))]
+fn new_wrapper() -> Wrapper {
+    Wrapper::new(0)
+}
+
+#[cfg(feature = "hyphenation")]
+fn new_wrapper() -> Wrapper {
+    let mut wrapper = Wrapper::new(0);
+    wrapper.splitter = Box::new(hyphenation::load(Language::English_US).unwrap());
+    wrapper
+}
 
 fn main() {
     let example = "
@@ -11,8 +26,7 @@ Concurrency without data races.
 Zero-cost abstractions.
 ";
     let mut prev_lines = vec![];
-    let mut wrapper = Wrapper::new(0);
-    wrapper.splitter = Box::new(hyphenation::load(Language::English_US).unwrap());
+    let mut wrapper = new_wrapper();
     for width in 15..60 {
         wrapper.width = width;
         let lines = wrapper.wrap(example);

--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -5,7 +5,6 @@ use hyphenation::Language;
 use textwrap::Wrapper;
 
 fn main() {
-    let corpus = hyphenation::load(Language::English_US).unwrap();
     let example = "
 Memory safety without garbage collection.
 Concurrency without data races.
@@ -13,7 +12,7 @@ Zero-cost abstractions.
 ";
     let mut prev_lines = vec![];
     let mut wrapper = Wrapper::new(0);
-    wrapper.corpus = Some(&corpus);
+    wrapper.corpus = Some(hyphenation::load(Language::English_US).unwrap());
     for width in 15..60 {
         wrapper.width = width;
         let lines = wrapper.wrap(example);

--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -12,7 +12,7 @@ Zero-cost abstractions.
 ";
     let mut prev_lines = vec![];
     let mut wrapper = Wrapper::new(0);
-    wrapper.corpus = Some(hyphenation::load(Language::English_US).unwrap());
+    wrapper.splitter = Box::new(hyphenation::load(Language::English_US).unwrap());
     for width in 15..60 {
         wrapper.width = width;
         let lines = wrapper.wrap(example);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,74 @@ use unicode_width::UnicodeWidthChar;
 use hyphenation::Hyphenation;
 use hyphenation::Corpus;
 
+pub trait WordSplitter {
+    /// Return all possible splits of word. Each split is a triple
+    /// with a head, a hyphen, and a tail where `head + &hyphen +
+    /// &tail == word`. The hyphen can be empty if there is already a
+    /// hyphen in the head.
+    ///
+    /// The splits should go from smallest to longest and should
+    /// include no split at all. So the word "technology" could be
+    /// split into
+    ///
+    /// ```
+    /// vec![("tech", "-", "nology"),
+    ///      ("technol", "-", "ogy"),
+    ///      ("technolo", "-", "gy"),
+    ///      ("technology", "", "")];
+    /// ```
+    fn split<'w>(&self, word: &'w str) -> Vec<(&'w str, &'w str, &'w str)>;
+}
+
+pub struct HyphenSplitter;
+
+/// HyphenSplitter is the default WordSplitter. As the name says, it
+/// will split words on any existing hyphens in the word.
+///
+/// It will only use hyphens that are surrounded by alphanumeric
+/// characters, which prevents a word like "--foo-bar" from being
+/// split on the first or second hyphen.
+impl WordSplitter for HyphenSplitter {
+    fn split<'w>(&self, word: &'w str) -> Vec<(&'w str, &'w str, &'w str)> {
+        let mut triples = Vec::new();
+        // Split on hyphens, smallest split first. We only use hyphens
+        // that are surrounded by alphanumeric characters. This is to
+        // avoid splitting on repeated hyphens, such as those found in
+        // --foo-bar.
+        let char_indices = word.char_indices().collect::<Vec<_>>();
+        for w in char_indices.windows(3) {
+            let ((_, prev), (n, c), (_, next)) = (w[0], w[1], w[2]);
+            if prev.is_alphanumeric() && c == '-' && next.is_alphanumeric() {
+                let (head, tail) = word.split_at(n + 1);
+                triples.push((head, "", tail));
+            }
+        }
+
+        // Finally option is no split at all.
+        triples.push((word, "", ""));
+
+        triples
+    }
+}
+
+/// A hyphenation Corpus can be used to do language-specific
+/// hyphenation using patterns from the hyphenation crate.
+impl WordSplitter for Corpus {
+    fn split<'w>(&self, word: &'w str) -> Vec<(&'w str, &'w str, &'w str)> {
+        // Find splits based on language corpus.
+        let mut triples = Vec::new();
+        for n in word.opportunities(&self) {
+            let (head, tail) = word.split_at(n);
+            let hyphen = if head.ends_with('-') { "" } else { "-" };
+            triples.push((head, hyphen, tail));
+        }
+        // Finally option is no split at all.
+        triples.push((word, "", ""));
+
+        triples
+    }
+}
+
 /// A Wrapper holds settings for wrapping and filling text.
 ///
 /// The algorithm used by the `wrap` method works by doing a single
@@ -41,9 +109,8 @@ pub struct Wrapper {
     /// Allow long words to be broken if they cannot fit on a line.
     /// When set to false, some lines be being longer than self.width.
     pub break_words: bool,
-    /// The hyphenation corpus (if any) used for automatic
-    /// hyphenation.
-    pub corpus: Option<Corpus>,
+    /// The method for splitting words, if any.
+    pub splitter: Box<WordSplitter>,
 }
 
 impl Wrapper {
@@ -54,7 +121,7 @@ impl Wrapper {
         Wrapper {
             width: width,
             break_words: true,
-            corpus: None,
+            splitter: Box::new(HyphenSplitter {}),
         }
     }
 
@@ -115,7 +182,7 @@ impl Wrapper {
 
             // If that failed, loop until nothing remains to be added.
             while !word.is_empty() {
-                let splits = self.split_word(word);
+                let splits = self.splitter.split(word);
                 let (smallest, hyphen, longest) = splits[0];
                 let min_width = smallest.width() + hyphen.len();
 
@@ -168,45 +235,6 @@ impl Wrapper {
             lines.push(line);
         }
         lines
-    }
-
-    /// Split word into all possible (head, hyphen, tail) triples.
-    /// Word must be non-empty. The returned vector will always be
-    /// non-empty.
-    fn split_word<'w>(&self, word: &'w str) -> Vec<(&'w str, &'w str, &'w str)> {
-        let mut triples = Vec::new();
-
-        // Split on hyphens or use the language corpus.
-        match self.corpus {
-            None => {
-                // Split on hyphens, smallest split first. We only use
-                // hyphens that are surrounded by alphanumeric
-                // characters. This is to avoid splitting on repeated
-                // hyphens, such as those found in --foo-bar.
-                let char_indices = word.char_indices().collect::<Vec<_>>();
-                for w in char_indices.windows(3) {
-                    let ((_, prev), (n, c), (_, next)) = (w[0], w[1], w[2]);
-                    if prev.is_alphanumeric() && c == '-' && next.is_alphanumeric() {
-                        let (head, tail) = word.split_at(n + 1);
-                        triples.push((head, "", tail));
-                    }
-                }
-            }
-            Some(ref corpus) => {
-                // Find splits based on language corpus. This includes
-                // the splits that would have been found above.
-                for n in word.opportunities(corpus) {
-                    let (head, tail) = word.split_at(n);
-                    let hyphen = if head.ends_with('-') { "" } else { "-" };
-                    triples.push((head, hyphen, tail));
-                }
-            }
-        }
-
-        // Finally option is no split at all.
-        triples.push((word, "", ""));
-
-        triples
     }
 
     /// Try to fit a word (or part of a word) onto a line. The line
@@ -482,7 +510,7 @@ mod tests {
         assert_eq!(wrapper.wrap("Internationalization"),
                    vec!["Internatio", "nalization"]);
 
-        wrapper.corpus = Some(corpus);
+        wrapper.splitter = Box::new(corpus);
         assert_eq!(wrapper.wrap("Internationalization"),
                    vec!["Interna-", "tionaliza-", "tion"]);
     }
@@ -494,7 +522,7 @@ mod tests {
         wrapper.break_words = false;
         assert_eq!(wrapper.wrap("over-caffinated"), vec!["over-", "caffinated"]);
 
-        wrapper.corpus = Some(corpus);
+        wrapper.splitter = Box::new(corpus);
         assert_eq!(wrapper.wrap("over-caffinated"),
                    vec!["over-", "caffi-", "nated"]);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,7 +173,7 @@ impl Wrapper {
     /// Split word into all possible (head, hyphen, tail) triples.
     /// Word must be non-empty. The returned vector will always be
     /// non-empty.
-    fn split_word<'b>(&self, word: &'b str) -> Vec<(&'b str, &'b str, &'b str)> {
+    fn split_word<'w>(&self, word: &'w str) -> Vec<(&'w str, &'w str, &'w str)> {
         let mut triples = Vec::new();
 
         // Split on hyphens or use the language corpus.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ use hyphenation::Corpus;
 /// scan over words in the input string and splitting them into one or
 /// more lines. The time and memory complexity is O(*n*) where *n* is
 /// the length of the input string.
-pub struct Wrapper<'a> {
+pub struct Wrapper {
     /// The width in columns at which the text will be wrapped.
     pub width: usize,
     /// Allow long words to be broken if they cannot fit on a line.
@@ -43,15 +43,15 @@ pub struct Wrapper<'a> {
     pub break_words: bool,
     /// The hyphenation corpus (if any) used for automatic
     /// hyphenation.
-    pub corpus: Option<&'a Corpus>,
+    pub corpus: Option<Corpus>,
 }
 
-impl<'a> Wrapper<'a> {
+impl Wrapper {
     /// Create a new Wrapper for wrapping at the specified width. By
     /// default, we allow words longer than `width` to be broken. No
     /// hyphenation corpus is loaded by default.
-    pub fn new(width: usize) -> Wrapper<'a> {
-        Wrapper::<'a> {
+    pub fn new(width: usize) -> Wrapper {
+        Wrapper {
             width: width,
             break_words: true,
             corpus: None,
@@ -192,7 +192,7 @@ impl<'a> Wrapper<'a> {
                     }
                 }
             }
-            Some(corpus) => {
+            Some(ref corpus) => {
                 // Find splits based on language corpus. This includes
                 // the splits that would have been found above.
                 for n in word.opportunities(corpus) {
@@ -482,7 +482,7 @@ mod tests {
         assert_eq!(wrapper.wrap("Internationalization"),
                    vec!["Internatio", "nalization"]);
 
-        wrapper.corpus = Some(&corpus);
+        wrapper.corpus = Some(corpus);
         assert_eq!(wrapper.wrap("Internationalization"),
                    vec!["Interna-", "tionaliza-", "tion"]);
     }
@@ -494,7 +494,7 @@ mod tests {
         wrapper.break_words = false;
         assert_eq!(wrapper.wrap("over-caffinated"), vec!["over-", "caffinated"]);
 
-        wrapper.corpus = Some(&corpus);
+        wrapper.corpus = Some(corpus);
         assert_eq!(wrapper.wrap("over-caffinated"),
                    vec!["over-", "caffi-", "nated"]);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,12 +22,13 @@
 
 
 extern crate unicode_width;
+#[cfg(feature = "hyphenation")]
 extern crate hyphenation;
 
 use unicode_width::UnicodeWidthStr;
 use unicode_width::UnicodeWidthChar;
-use hyphenation::Hyphenation;
-use hyphenation::Corpus;
+#[cfg(feature = "hyphenation")]
+use hyphenation::{Hyphenation, Corpus};
 
 pub trait WordSplitter {
     /// Return all possible splits of word. Each split is a triple
@@ -81,6 +82,7 @@ impl WordSplitter for HyphenSplitter {
 
 /// A hyphenation Corpus can be used to do language-specific
 /// hyphenation using patterns from the hyphenation crate.
+#[cfg(feature = "hyphenation")]
 impl WordSplitter for Corpus {
     fn split<'w>(&self, word: &'w str) -> Vec<(&'w str, &'w str, &'w str)> {
         // Find splits based on language corpus.
@@ -399,8 +401,10 @@ pub fn dedent(s: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "hyphenation")]
     extern crate hyphenation;
 
+    #[cfg(feature = "hyphenation")]
     use hyphenation::Language;
     use super::*;
 
@@ -504,6 +508,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "hyphenation")]
     fn auto_hyphenation() {
         let corpus = hyphenation::load(Language::English_US).unwrap();
         let mut wrapper = Wrapper::new(10);
@@ -516,6 +521,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "hyphenation")]
     fn auto_hyphenation_with_hyphen() {
         let corpus = hyphenation::load(Language::English_US).unwrap();
         let mut wrapper = Wrapper::new(8);


### PR DESCRIPTION
This refactors the code so that hyphenation is done via a WordSplitter trait. Automatic hyphenation then becomes a matter of configuring the right implementation of this trait -- and this in turn makes it possible to make hyphenation optional.

Fixes #36.