### PR TITLE
appveyor: test with and without hyphenation

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,22 @@
 environment:
   matrix:
   - TOOLCHAIN: 1.13.0
+    FEATURES: ""
   - TOOLCHAIN: stable
+    FEATURES: ""
   - TOOLCHAIN: beta
+    FEATURES: ""
   - TOOLCHAIN: nightly
+    FEATURES: ""
+
+  - TOOLCHAIN: 1.13.0
+    FEATURES: "hyphenation"
+  - TOOLCHAIN: stable
+    FEATURES: "hyphenation"
+  - TOOLCHAIN: beta
+    FEATURES: "hyphenation"
+  - TOOLCHAIN: nightly
+    FEATURES: "hyphenation"
 
 matrix:
   allow_failures:
@@ -15,10 +28,10 @@ install:
   - set PATH=%PATH%;%USERPROFILE%\.cargo\bin
 
 build_script:
-  - cargo build --verbose
+  - cargo build --verbose --features "%FEATURES%"
 
 test_script:
-  - cargo test --verbose
+  - cargo test --verbose --features "%FEATURES%"
 
 cache:
   - '%USERPROFILE%\.cargo'


### PR DESCRIPTION
This expands the matrix for AppVeyor to test both with and without the `hyphenation` feature -- just as for Travis CI.