### PR TITLE
Wrapper: add with_termwidth function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,5 @@ appveyor = { repository = "mgeisler/textwrap" }
 
 [dependencies]
 unicode-width = "0.1.3"
+term_size = "0.3.0"
 hyphenation = { version = "0.6.1", optional = true }

--- a/README.md
+++ b/README.md
@@ -83,8 +83,13 @@ The hyphenation uses high-quality TeX hyphenation patterns.
 
 ## Examples
 
-The library comes with a small example program that shows how a fixed
-example string is wrapped at different widths. Run the example with:
+The library comes with a small example programs that shows various
+features.
+
+### Layout Example
+
+The `layout` example shows how a fixed example string is wrapped at
+different widths. Run the example with:
 
 ```shell
 $ cargo run --features hyphenation --example layout
@@ -134,6 +139,36 @@ Later, longer lines are used and the output now looks like this:
 
 Notice how words are split at hyphens (such a s "zero-cost") but also
 how words are hyphenated using automatic/machine hyphenation.
+
+### Terminal Width Example
+
+The `termwidth` example simply shows how the width can be set
+automatically to the current terminal width. Run it with this command:
+
+```
+$ cargo run --example termwidth
+```
+
+If you run it in a narrow terminal, you'll see output like this:
+```
+Formatted in within 60 columns:
+----
+Memory safety without garbage collection. Concurrency
+without data races. Zero-cost abstractions.
+----
+```
+
+If `stdout` is not connected to the terminal, the program will use a
+default of 80 columns for the width:
+
+```
+$ cargo run --example termwidth | cat
+Formatted in within 80 columns:
+----
+Memory safety without garbage collection. Concurrency without data races. Zero-
+cost abstractions.
+----
+```
 
 ## Release History
 

--- a/examples/termwidth.rs
+++ b/examples/termwidth.rs
@@ -1,0 +1,18 @@
+extern crate textwrap;
+
+use textwrap::Wrapper;
+
+fn main() {
+    let example = "
+Memory safety without garbage collection.
+Concurrency without data races.
+Zero-cost abstractions.
+";
+    // Create a new Wrapper -- automatically set the width to the
+    // current terminal width.
+    let wrapper = Wrapper::with_termwidth();
+    println!("Formatted in within {} columns:", wrapper.width);
+    println!("----");
+    println!("{}", wrapper.fill(example));
+    println!("----");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@
 
 
 extern crate unicode_width;
+extern crate term_size;
 #[cfg(feature = "hyphenation")]
 extern crate hyphenation;
 
@@ -125,6 +126,15 @@ impl Wrapper {
             break_words: true,
             splitter: Box::new(HyphenSplitter {}),
         }
+    }
+
+    /// Crate a new Wrapper for wrapping text at the current terminal
+    /// width. If the terminal width cannot be determined (typically
+    /// because the standard input and output is not connected to a
+    /// terminal), a width of 80 characters will be used. Other
+    /// settings use the same defaults as `Wrapper::new`.
+    pub fn with_termwidth() -> Wrapper {
+        Wrapper::new(term_size::dimensions_stdout().map_or(80, |(w, _)| w))
     }
 
     /// Fill a line of text at `self.width` characters. Strings are


### PR DESCRIPTION
This function will create a Wrapper with its width set to the current
terminal width.

Fixes #19.