### PR TITLE
Wrapper::with_termwidth: add missing lifetime parameter

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,7 +183,7 @@ impl<'a> Wrapper<'a> {
     /// because the standard input and output is not connected to a
     /// terminal), a width of 80 characters will be used. Other
     /// settings use the same defaults as `Wrapper::new`.
-    pub fn with_termwidth() -> Wrapper {
+    pub fn with_termwidth() -> Wrapper<'a> {
         Wrapper::new(term_size::dimensions_stdout().map_or(80, |(w, _)| w))
     }
 


### PR DESCRIPTION
This function got merged in after the support for custom indentation
was added, which in turn added a lifetime parameter to the Wrapper
class. So while there were no merge conflict, the new with_termwidth
function caused a build failure.