### PR TITLE
travis: test default features first

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ script:
   - cargo test --verbose --features "$FEATURES"
 
 env:
-  - FEATURES="hyphenation"
   - FEATURES=""
+  - FEATURES="hyphenation"
 
 matrix:
   include:


### PR DESCRIPTION
This makes Travis test without the hyphenation feature first, which
could speed up detecting errors.