### PR TITLE
Wrapper: add builder methods

### DIFF
--- a/benches/linear.rs
+++ b/benches/linear.rs
@@ -60,9 +60,7 @@ fn lorem_800(b: &mut Bencher) {
 fn hyphenation_lorem_100(b: &mut Bencher) {
     let text = lorem_ipsum(100);
     let corpus = hyphenation::load(Language::Latin).unwrap();
-    let mut wrapper = Wrapper::new(LINE_LENGTH);
-    wrapper.splitter = Box::new(corpus);
-
+    let wrapper = Wrapper::new(LINE_LENGTH).word_splitter(Box::new(corpus));
     b.iter(|| wrapper.fill(text))
 }
 
@@ -71,9 +69,7 @@ fn hyphenation_lorem_100(b: &mut Bencher) {
 fn hyphenation_lorem_200(b: &mut Bencher) {
     let text = lorem_ipsum(200);
     let corpus = hyphenation::load(Language::Latin).unwrap();
-    let mut wrapper = Wrapper::new(LINE_LENGTH);
-    wrapper.splitter = Box::new(corpus);
-
+    let wrapper = Wrapper::new(LINE_LENGTH).word_splitter(Box::new(corpus));
     b.iter(|| wrapper.fill(text))
 }
 
@@ -82,9 +78,7 @@ fn hyphenation_lorem_200(b: &mut Bencher) {
 fn hyphenation_lorem_400(b: &mut Bencher) {
     let text = lorem_ipsum(400);
     let corpus = hyphenation::load(Language::Latin).unwrap();
-    let mut wrapper = Wrapper::new(LINE_LENGTH);
-    wrapper.splitter = Box::new(corpus);
-
+    let wrapper = Wrapper::new(LINE_LENGTH).word_splitter(Box::new(corpus));
     b.iter(|| wrapper.fill(text))
 }
 
@@ -93,8 +87,6 @@ fn hyphenation_lorem_400(b: &mut Bencher) {
 fn hyphenation_lorem_800(b: &mut Bencher) {
     let text = lorem_ipsum(800);
     let corpus = hyphenation::load(Language::Latin).unwrap();
-    let mut wrapper = Wrapper::new(LINE_LENGTH);
-    wrapper.splitter = Box::new(corpus);
-
+    let wrapper = Wrapper::new(LINE_LENGTH).word_splitter(Box::new(corpus));
     b.iter(|| wrapper.fill(text))
 }

--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -14,9 +14,8 @@ fn new_wrapper<'a>() -> Wrapper<'a> {
 
 #[cfg(feature = "hyphenation")]
 fn new_wrapper<'a>() -> Wrapper<'a> {
-    let mut wrapper = Wrapper::new(0);
-    wrapper.splitter = Box::new(hyphenation::load(Language::English_US).unwrap());
-    wrapper
+    let corpus = hyphenation::load(Language::English_US).unwrap();
+    Wrapper::new(0).word_splitter(Box::new(corpus))
 }
 
 fn main() {


### PR DESCRIPTION
The new methods are named after the struct fields they modify. Using
them makes it easy to create and configure a Wrapper:

    let wrapper = Wrapper::new(78).break_words(false)
                                  .initial_indent("* ")
                                  .subsequent_indent("  ");

The methods consume self since that means one can create a wrapper
like above. If the methods had taken &mut self as suggested in

  https://github.com/brson/rust-api-guidelines#c-builder

the above would fail with

> error: borrowed value does not live long enough

since the Wrapper::new value is a temporary value that is dropped at
the end of the line.