### PR TITLE
appveyor: remove non-essential jobs

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,19 +1,6 @@
 environment:
   matrix:
-  - TOOLCHAIN: 1.8.0
-    FEATURES: ""
   - TOOLCHAIN: stable
-    FEATURES: ""
-  - TOOLCHAIN: beta
-    FEATURES: ""
-  - TOOLCHAIN: nightly
-    FEATURES: ""
-
-  - TOOLCHAIN: 1.13.0
-    FEATURES: "hyphenation"
-  - TOOLCHAIN: stable
-    FEATURES: "hyphenation"
-  - TOOLCHAIN: beta
     FEATURES: "hyphenation"
   - TOOLCHAIN: nightly
     FEATURES: "hyphenation"


### PR DESCRIPTION
AppVeyor is really slow and the jobs are run one at a time on the free
plan for open source projects. A full build with 8 different jobs
takes around 15-20 minutes to complete. It sometimes takes longer if
the build cache is slow to download. Given that a PR triggers two full
builds, we're talking about at least 30 minutes delay per PR.

This removes most of the jobs from the configuration. Instead of
testing both with and without the hyphenation feature, we now always
test with it -- this covers most if not all code paths. We now also
only test on stable and nightly since this should cover what most
users are using.

TravisCI will continue to test the other configurations and since we
have no platform dependent code, this should be more than enough.