### PR TITLE
cargo: instruct docs.rs to build all features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,9 @@ keywords = ["text", "formatting", "wrap", "typesetting", "hyphenation"]
 categories = ["text-processing", "command-line-interface"]
 license = "MIT"
 
+[package.metadata.docs.rs]
+all-features = true
+
 [badges]
 travis-ci = { repository = "mgeisler/textwrap" }
 appveyor = { repository = "mgeisler/textwrap" }


### PR DESCRIPTION
This means that the hyphenation feature will be enabled when building
documentation. This in turn means that people will have an easier time
finding the WordSplitter trait implementation for the Corpus type from
the hyphenation crate.