### PR TITLE
rustfmt: add config file

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,6 @@
+array_layout = "Visual"
+control_style = "Legacy"
+fn_args_layout = "Visual"
+fn_call_style = "Visual"
+generics_indent = "Visual"
+struct_lit_width = 40

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,10 +179,7 @@ impl IndentedString {
     fn new(indent: &str, capacity: usize) -> IndentedString {
         let mut value = String::with_capacity(capacity);
         value.push_str(indent);
-        IndentedString {
-            value: value,
-            empty_len: indent.len(),
-        }
+        IndentedString { value: value, empty_len: indent.len() }
     }
 
     /// Returns `true` if the string has no other content apart from


### PR DESCRIPTION
This configuration mostly matches the existing code style, which I
happen to like. Compared to the new style agreed upon in the RFC
process, this style uses more visual layouts.

With the struct_lit_width setting, small struct literals are put onto
a single line.