### PR TITLE
Rewrite wrap to borrow from input string

### DIFF
--- a/benches/linear.rs
+++ b/benches/linear.rs
@@ -51,6 +51,32 @@ fn fill_800(b: &mut Bencher) {
     b.iter(|| textwrap::fill(text, LINE_LENGTH))
 }
 
+
+#[bench]
+fn wrap_100(b: &mut Bencher) {
+    let text = &lorem_ipsum(100);
+    b.iter(|| textwrap::wrap(text, LINE_LENGTH))
+}
+
+#[bench]
+fn wrap_200(b: &mut Bencher) {
+    let text = &lorem_ipsum(200);
+    b.iter(|| textwrap::wrap(text, LINE_LENGTH))
+}
+
+#[bench]
+fn wrap_400(b: &mut Bencher) {
+    let text = &lorem_ipsum(400);
+    b.iter(|| textwrap::wrap(text, LINE_LENGTH))
+}
+
+#[bench]
+fn wrap_800(b: &mut Bencher) {
+    let text = &lorem_ipsum(800);
+    b.iter(|| textwrap::wrap(text, LINE_LENGTH))
+}
+
+
 #[bench]
 #[cfg(feature = "hyphenation")]
 fn hyphenation_fill_100(b: &mut Bencher) {

--- a/benches/linear.rs
+++ b/benches/linear.rs
@@ -28,32 +28,32 @@ fn lorem_ipsum(length: usize) -> String {
 }
 
 #[bench]
-fn lorem_100(b: &mut Bencher) {
+fn fill_100(b: &mut Bencher) {
     let text = &lorem_ipsum(100);
     b.iter(|| textwrap::fill(text, LINE_LENGTH))
 }
 
 #[bench]
-fn lorem_200(b: &mut Bencher) {
+fn fill_200(b: &mut Bencher) {
     let text = &lorem_ipsum(200);
     b.iter(|| textwrap::fill(text, LINE_LENGTH))
 }
 
 #[bench]
-fn lorem_400(b: &mut Bencher) {
+fn fill_400(b: &mut Bencher) {
     let text = &lorem_ipsum(400);
     b.iter(|| textwrap::fill(text, LINE_LENGTH))
 }
 
 #[bench]
-fn lorem_800(b: &mut Bencher) {
+fn fill_800(b: &mut Bencher) {
     let text = &lorem_ipsum(800);
     b.iter(|| textwrap::fill(text, LINE_LENGTH))
 }
 
 #[bench]
 #[cfg(feature = "hyphenation")]
-fn hyphenation_lorem_100(b: &mut Bencher) {
+fn hyphenation_fill_100(b: &mut Bencher) {
     let text = &lorem_ipsum(100);
     let corpus = hyphenation::load(Language::Latin).unwrap();
     let wrapper = Wrapper::new(LINE_LENGTH).word_splitter(Box::new(corpus));
@@ -62,7 +62,7 @@ fn hyphenation_lorem_100(b: &mut Bencher) {
 
 #[bench]
 #[cfg(feature = "hyphenation")]
-fn hyphenation_lorem_200(b: &mut Bencher) {
+fn hyphenation_fill_200(b: &mut Bencher) {
     let text = &lorem_ipsum(200);
     let corpus = hyphenation::load(Language::Latin).unwrap();
     let wrapper = Wrapper::new(LINE_LENGTH).word_splitter(Box::new(corpus));
@@ -71,7 +71,7 @@ fn hyphenation_lorem_200(b: &mut Bencher) {
 
 #[bench]
 #[cfg(feature = "hyphenation")]
-fn hyphenation_lorem_400(b: &mut Bencher) {
+fn hyphenation_fill_400(b: &mut Bencher) {
     let text = &lorem_ipsum(400);
     let corpus = hyphenation::load(Language::Latin).unwrap();
     let wrapper = Wrapper::new(LINE_LENGTH).word_splitter(Box::new(corpus));
@@ -80,7 +80,7 @@ fn hyphenation_lorem_400(b: &mut Bencher) {
 
 #[bench]
 #[cfg(feature = "hyphenation")]
-fn hyphenation_lorem_800(b: &mut Bencher) {
+fn hyphenation_fill_800(b: &mut Bencher) {
     let text = &lorem_ipsum(800);
     let corpus = hyphenation::load(Language::Latin).unwrap();
     let wrapper = Wrapper::new(LINE_LENGTH).word_splitter(Box::new(corpus));

--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -19,11 +19,9 @@ fn new_wrapper<'a>() -> Wrapper<'a> {
 }
 
 fn main() {
-    let example = "
-Memory safety without garbage collection.
-Concurrency without data races.
-Zero-cost abstractions.
-";
+    let example = "Memory safety without garbage collection. \
+                   Concurrency without data races. \
+                   Zero-cost abstractions.";
     let mut prev_lines = vec![];
     let mut wrapper = new_wrapper();
     for width in 15..60 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,23 @@ use hyphenation::{Hyphenation, Corpus};
 /// A non-breaking space.
 const NBSP: char = '\u{a0}';
 
+/// Remove trailing whitespace by truncating the string. The truncated
+/// string is returned back to the caller.
+fn truncate_whitespace(mut s: String) -> String {
+    let mut idx = None;
+    for (i, ch) in s.char_indices().rev() {
+        if !ch.is_whitespace() || ch == NBSP {
+            break;
+        }
+        idx = Some(i);
+    }
+    if let Some(i) = idx {
+        s.truncate(i);
+    }
+
+    s
+}
+
 /// An interface for splitting words.
 ///
 /// When the [`wrap`] method will try to fit text into a line, it will
@@ -405,7 +422,7 @@ impl<'a> Wrapper<'a> {
                 // Add a new line if even the smallest split doesn't
                 // fit.
                 if !line.is_empty() && 1 + min_width > remaining {
-                    lines.push(line.into_string());
+                    lines.push(truncate_whitespace(line.into_string()));
                     line = IndentedString::new(self.subsequent_indent, self.width);
                     remaining = self.width - self.subsequent_indent.width();
                 }
@@ -680,7 +697,7 @@ mod tests {
         // gets too long and is broken, the first word starts in
         // column zero and is not indented. The line before might end
         // up with trailing whitespace.
-        assert_eq!(wrap("foo               bar", 5), vec!["foo  ", "bar"]);
+        assert_eq!(wrap("foo               bar", 5), vec!["foo", "bar"]);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -606,7 +606,17 @@ mod tests {
     }
 
     #[test]
-    fn whitespace_is_significant() {
+    fn leading_whitespace() {
+        assert_eq!(wrap("  foo bar", 6), vec!["  foo", "bar"]);
+    }
+
+    #[test]
+    fn trailing_whitespace() {
+        assert_eq!(wrap("foo bar  ", 6), vec!["foo", "bar  "]);
+    }
+
+    #[test]
+    fn interior_whitespace() {
         assert_eq!(wrap("foo:   bar baz", 10), vec!["foo:   bar", "baz"]);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,9 @@ use unicode_width::UnicodeWidthChar;
 #[cfg(feature = "hyphenation")]
 use hyphenation::{Hyphenation, Corpus};
 
+/// A non-breaking space.
+const NBSP: char = '\u{a0}';
+
 /// An interface for splitting words.
 ///
 /// When the [`wrap`] method will try to fit text into a line, it will
@@ -381,7 +384,6 @@ impl<'a> Wrapper<'a> {
         let mut lines = Vec::with_capacity(s.len() / (self.width + 1));
         let mut line = IndentedString::new(self.initial_indent, self.width);
         let mut remaining = self.width - self.initial_indent.width();
-        const NBSP: char = '\u{a0}'; // non-breaking space
 
         for mut word in s.split(|c: char| c.is_whitespace() && c != NBSP) {
             // Skip over adjacent whitespace characters.


### PR DESCRIPTION
This changes the implementation of `Wrapper::wrap` to borrow from the input string (where possible). The return type is now `Vec<Cow<str>>` instead of `Vec<String>` and so this can be a breaking change (but doesn't have to be if the lines are used in a way compatible with `Cow<str>`, such as how the `layout` example works).

Furthermore, the `squeeze_whitespace` option has been dropped since it seemed cumbersome to implement it with the new algorithm. If this is a concern, please let us know so we can supply a suitable work around.