### PR TITLE
termwidth: fix spurious whitespace in example

### DIFF
--- a/examples/termwidth.rs
+++ b/examples/termwidth.rs
@@ -3,11 +3,9 @@ extern crate textwrap;
 use textwrap::Wrapper;
 
 fn main() {
-    let example = "
-Memory safety without garbage collection.
-Concurrency without data races.
-Zero-cost abstractions.
-";
+    let example = "Memory safety without garbage collection. \
+                   Concurrency without data races. \
+                   Zero-cost abstractions.";
     // Create a new Wrapper -- automatically set the width to the
     // current terminal width.
     let wrapper = Wrapper::with_termwidth();


### PR DESCRIPTION
With the new wrapping algorith in 0.7.0, whitespace between the words
is suddenly significant.