### PR TITLE
Revert "appveyor: temporarily disable SSL revocation checking"

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,25 +1,4 @@
 environment:
-  # From https://github.com/rust-lang-nursery/rand/commit/bb78689:
-  #
-  # At the time this was added AppVeyor was having troubles with checking
-  # revocation of SSL certificates of sites like static.rust-lang.org and what
-  # we think is crates.io. The libcurl HTTP client by default checks for
-  # revocation on Windows and according to a mailing list [1] this can be
-  # disabled.
-  #
-  # The `CARGO_HTTP_CHECK_REVOKE` env var here tells cargo to disable SSL
-  # revocation checking on Windows in libcurl. Note, though, that rustup, which
-  # we're using to download Rust here, also uses libcurl as the default backend.
-  # Unlike Cargo, however, rustup doesn't have a mechanism to disable revocation
-  # checking. To get rustup working we set `RUSTUP_USE_HYPER` which forces it to
-  # use the Hyper instead of libcurl backend. Both Hyper and libcurl use
-  # schannel on Windows but it appears that Hyper configures it slightly
-  # differently such that revocation checking isn't turned on by default.
-  #
-  # [1]: https://curl.haxx.se/mail/lib-2016-03/0202.html
-  RUSTUP_USE_HYPER: 1
-  CARGO_HTTP_CHECK_REVOKE: false
-
   matrix:
   - TOOLCHAIN: stable
     FEATURES: "hyphenation"


### PR DESCRIPTION
This reverts commit 9af06ab996668485f411d5e408024e4ef4d4ce3d.

AppVeyor has fixed their firewall rules, so this is no longer needed.