### PR TITLE
benches: ensure deterministic inputs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,4 +30,5 @@ term_size = "0.3.0"
 hyphenation = { version = "0.6.1", optional = true }
 
 [dev-dependencies]
-lipsum = "0.2"
+lipsum = "0.3"
+rand = "0.3"

--- a/benches/linear.rs
+++ b/benches/linear.rs
@@ -4,6 +4,7 @@
 // where *n* is the number of characters in the text to be wrapped.
 
 extern crate test;
+extern crate rand;
 extern crate lipsum;
 extern crate textwrap;
 #[cfg(feature = "hyphenation")]
@@ -14,6 +15,8 @@ use test::Bencher;
 use hyphenation::Language;
 #[cfg(feature = "hyphenation")]
 use textwrap::Wrapper;
+use rand::XorShiftRng;
+use lipsum::MarkovChain;
 
 const LINE_LENGTH: usize = 60;
 
@@ -22,7 +25,12 @@ fn lorem_ipsum(length: usize) -> String {
     // The average word length in the lorem ipsum text is somewhere
     // between 6 and 7. So we conservatively divide by 5 to have a
     // long enough text that we can truncate below.
-    let mut text = lipsum::lipsum(length / 5);
+    let rng = XorShiftRng::new_unseeded();
+    let mut chain = MarkovChain::new_with_rng(rng);
+    chain.learn(lipsum::LOREM_IPSUM);
+    chain.learn(lipsum::LIBER_PRIMUS);
+
+    let mut text = chain.generate_from(length / 5, ("Lorem", "ipsum"));
     text.truncate(length);
     text
 }


### PR DESCRIPTION
Before, we used the lipsum function which generates random output on
every call. We now construct the Markov chain ourselves and use a
predictable random number generator to ensure that we get identical
lorem ipsum text on every execution.

For fun, I ran the fill_800 benchmark 100 times and looked at the
results with ministat(1):
```
  x master
  + deterministic-lorem-ipsum
  +--------------------------------------------------------------------------+
  |                              +                                           |
  |                              +                                           |
  |                             ++ +                                         |
  |                             ++ +                                         |
  |                             ++ +                                         |
  |                             ++ +                                         |
  |                          +  ++ +                                         |
  |                          +  ++++                                         |
  |                    x     +  ++++                                         |
  |                    x     ++ ++++                                         |
  |                    xx  x+++ ++++  ++                                     |
  |            x    xx xx  **++*++*+++++x                                    |
  |           xx x xxx xxx **+**++**+*++x   x                                |
  |       x   xx x xxxxxxxx*********+*++x  xx    x       x   +               |
  |x      xx  xx xxxxxxxxxx*************x*+xx xx x x    +xxx +              x|
  |              |__________M_A___________|                                  |
  |                         |____MA_____|                                    |
  +--------------------------------------------------------------------------+
      N           Min           Max        Median           Avg        Stddev
  x 100          6018          6654          6234       6249.96     106.75526
  + 100          6225          6523          6279       6287.31      48.77814
```
As can be seen from the statistics, the standard deviation is smaller
with the deterministic inputs.