### PR TITLE
Wordsplitter specialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ use textwrap::Wrapper;
 
 fn main() {
     let corpus = hyphenation::load(Language::English_US).unwrap();
-    let wrapper = Wrapper::new(18).word_splitter(Box::new(corpus));
+    let wrapper = Wrapper::with_splitter(18, corpus);
     let text = "textwrap: a small library for wrapping text.";
     println!("{}", wrapper.fill(text))
 }
@@ -172,6 +172,13 @@ cost abstractions.
 ## Release History
 
 This section lists the largest changes per release.
+
+### Unreleased
+
+The `Wrapper` stuct now is now generic over the type of word splitter
+being used. This means less boxing is needed, which gives a nicer API.
+This is a *breaking API change* if you used `Wrapper::word_splitter`
+to change the word splitter on the fly.
 
 ### Version 0.7.0 — July 20th, 2017
 

--- a/benches/linear.rs
+++ b/benches/linear.rs
@@ -90,7 +90,7 @@ fn wrap_800(b: &mut Bencher) {
 fn hyphenation_fill_100(b: &mut Bencher) {
     let text = &lorem_ipsum(100);
     let corpus = hyphenation::load(Language::Latin).unwrap();
-    let wrapper = Wrapper::new(LINE_LENGTH).word_splitter(Box::new(corpus));
+    let wrapper = Wrapper::with_splitter(LINE_LENGTH, corpus);
     b.iter(|| wrapper.fill(text))
 }
 
@@ -99,7 +99,7 @@ fn hyphenation_fill_100(b: &mut Bencher) {
 fn hyphenation_fill_200(b: &mut Bencher) {
     let text = &lorem_ipsum(200);
     let corpus = hyphenation::load(Language::Latin).unwrap();
-    let wrapper = Wrapper::new(LINE_LENGTH).word_splitter(Box::new(corpus));
+    let wrapper = Wrapper::with_splitter(LINE_LENGTH, corpus);
     b.iter(|| wrapper.fill(text))
 }
 
@@ -108,7 +108,7 @@ fn hyphenation_fill_200(b: &mut Bencher) {
 fn hyphenation_fill_400(b: &mut Bencher) {
     let text = &lorem_ipsum(400);
     let corpus = hyphenation::load(Language::Latin).unwrap();
-    let wrapper = Wrapper::new(LINE_LENGTH).word_splitter(Box::new(corpus));
+    let wrapper = Wrapper::with_splitter(LINE_LENGTH, corpus);
     b.iter(|| wrapper.fill(text))
 }
 
@@ -117,6 +117,6 @@ fn hyphenation_fill_400(b: &mut Bencher) {
 fn hyphenation_fill_800(b: &mut Bencher) {
     let text = &lorem_ipsum(800);
     let corpus = hyphenation::load(Language::Latin).unwrap();
-    let wrapper = Wrapper::new(LINE_LENGTH).word_splitter(Box::new(corpus));
+    let wrapper = Wrapper::with_splitter(LINE_LENGTH, corpus);
     b.iter(|| wrapper.fill(text))
 }

--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -8,14 +8,14 @@ use textwrap::Wrapper;
 
 
 #[cfg(not(feature = "hyphenation"))]
-fn new_wrapper<'a>() -> Wrapper<'a> {
+fn new_wrapper<'a>() -> Wrapper<'a, textwrap::HyphenSplitter> {
     Wrapper::new(0)
 }
 
 #[cfg(feature = "hyphenation")]
-fn new_wrapper<'a>() -> Wrapper<'a> {
+fn new_wrapper<'a>() -> Wrapper<'a, hyphenation::Corpus> {
     let corpus = hyphenation::load(Language::English_US).unwrap();
-    Wrapper::new(0).word_splitter(Box::new(corpus))
+    Wrapper::with_splitter(0, corpus)
 }
 
 fn main() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -248,7 +248,7 @@ impl<'a> Wrapper<'a, HyphenSplitter> {
     /// terminal), a width of 80 characters will be used. Other
     /// settings use the same defaults as `Wrapper::new`.
     pub fn with_termwidth() -> Wrapper<'a, HyphenSplitter> {
-        Wrapper::new(term_size::dimensions_stdout().map_or(80, |(w, _)| w))
+        Wrapper::new(termwidth())
     }
 }
 
@@ -441,6 +441,27 @@ impl<'a, S: WordSplitter> Wrapper<'a, S> {
 
         lines
     }
+}
+
+/// Return the current terminal width. If the terminal width cannot be
+/// determined (typically because the standard output is not connected
+/// to a terminal), a default width of 80 characters will be used.
+///
+/// # Examples
+///
+/// Create a `Wrapper` for the current terminal with a two column
+/// margin:
+///
+/// ```
+/// use textwrap::{Wrapper, NoHyphenation, termwidth};
+///
+/// let width = termwidth() - 4; // Two columns on each side.
+/// let wrapper = Wrapper::with_splitter(width, NoHyphenation)
+///     .initial_indent("  ")
+///     .subsequent_indent("  ");
+/// ```
+pub fn termwidth() -> usize {
+    term_size::dimensions_stdout().map_or(80, |(w, _)| w)
 }
 
 /// Fill a line of text at `width` characters. Strings are wrapped

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,6 +247,14 @@ impl<'a> Wrapper<'a, HyphenSplitter> {
     /// because the standard input and output is not connected to a
     /// terminal), a width of 80 characters will be used. Other
     /// settings use the same defaults as `Wrapper::new`.
+    ///
+    /// Equivalent to:
+    ///
+    /// ```
+    /// use textwrap::{Wrapper, termwidth};
+    ///
+    /// let wrapper = Wrapper::new(termwidth());
+    /// ```
     pub fn with_termwidth() -> Wrapper<'a, HyphenSplitter> {
         Wrapper::new(termwidth())
     }


### PR DESCRIPTION
This PR changes the `Wrapper` struct so it becomes generic over the type of word splitter used. I think this gives a somewhat better API, but it has the cost that one cannot change the word splitter used on an existing wrapper. I don't think that is something one would do very open, though.