### PR TITLE
lib: set html_root_url to docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "textwrap"
-version = "0.7.0"
+version = "0.7.0" # Remember to update html_root_url.
 authors = ["Martin Geisler <martin@geisler.net>"]
 description = """
 Textwrap is a small library for word wrapping, indenting, and

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@
 //!
 //! [unicode-width]: https://docs.rs/unicode-width/
 
+#![doc(html_root_url = "https://docs.rs/textwrap/0.7.0")]
 #![deny(missing_docs)]
 
 extern crate unicode_width;


### PR DESCRIPTION
With this attribute set, crates that depend on textwrap will correctly
link to our documentation on docs.rs when they generate links to
functions and structs in our public API.

Fixes #81.