### PR TITLE
Make wrap_iter return a borrowing iterator

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -743,12 +743,18 @@ pub fn wrap(s: &str, width: usize) -> Vec<Cow<str>> {
 /// ```
 ///
 /// This function creates a Wrapper on the fly with default settings.
+/// It then calls the [`into_wrap_iter`] method. Hence, the return
+/// value is an [`IntoWrapIter`], not a [`WrapIter`] as the function
+/// name would otherwise suggest.
+///
 /// If you need to set a language corpus for automatic hyphenation, or
 /// need to wrap many strings, then it is suggested to create Wrapper
 /// and call its [`wrap_iter`] or [`into_wrap_iter`] methods.
 ///
 /// [`wrap_iter`]: struct.Wrapper.html#method.wrap_iter
 /// [`into_wrap_iter`]: struct.Wrapper.html#method.into_wrap_iter
+/// [`IntoWrapIter`]: struct.IntoWrapIter.html
+/// [`WrapIter`]: struct.WrapIter.html
 pub fn wrap_iter<'s>(s: &'s str, width: usize) -> IntoWrapIter<'s, HyphenSplitter> {
     Wrapper::new(width).into_wrap_iter(s)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -411,17 +411,17 @@ impl<'a, S: WordSplitter> Wrapper<'a, S> {
     /// By changing the field, different hyphenation strategies can be
     /// implemented.
     ///
-    /// This method consumes the `Wrapper` and returns a [`WrapIter`]
+    /// This method consumes the `Wrapper` and returns a [`IntoWrapIter`]
     /// iterator of lines. If processed fully, it has an O(*n*) time and
     /// memory complexity where *n* is the input string length.
     ///
     /// [`self.splitter`]: #structfield.splitter
     /// [`WordSplitter`]: trait.WordSplitter.html
-    /// [`WrapIter`]: struct.WrapIter.html
-    pub fn into_wrap_iter(self, s: &'a str) -> WrapIter<'a, S> {
+    /// [`IntoWrapIter`]: struct.IntoWrapIter.html
+    pub fn into_wrap_iter(self, s: &'a str) -> IntoWrapIter<'a, S> {
         let wrap_iter_impl = WrapIterImpl::new(&self, s);
 
-        WrapIter {
+        IntoWrapIter {
             wrapper: self,
             wrap_iter_impl: wrap_iter_impl,
         }
@@ -471,20 +471,20 @@ impl<'w, 'a: 'w, S: WordSplitter> Wrapper<'a, S> {
 
 
 /// An iterator over the lines of the input string which owns a
-/// `Wrapper`. An instance of `WrapIter` is typically obtained through
-/// either [`wrap_iter`] or [`Wrapper::into_wrap_iter`].
+/// `Wrapper`. An instance of `IntoWrapIter` is typically obtained
+/// through either [`wrap_iter`] or [`Wrapper::into_wrap_iter`].
 ///
 /// Each call of `.next()` method yields a line wrapped in `Some` if the
 /// input hasn't been fully processed yet. Otherwise it returns `None`.
 ///
 /// [`wrap_iter`]: fn.wrap_iter.html
 /// [`Wrapper::into_wrap_iter`]: struct.Wrapper.html#method.into_wrap_iter
-pub struct WrapIter<'a, S: WordSplitter> {
+pub struct IntoWrapIter<'a, S: WordSplitter> {
     wrapper: Wrapper<'a, S>,
     wrap_iter_impl: WrapIterImpl<'a>,
 }
 
-impl<'a, S: WordSplitter> Iterator for WrapIter<'a, S> {
+impl<'a, S: WordSplitter> Iterator for IntoWrapIter<'a, S> {
     type Item = Cow<'a, str>;
 
     fn next(&mut self) -> Option<Cow<'a, str>> {
@@ -749,7 +749,7 @@ pub fn wrap(s: &str, width: usize) -> Vec<Cow<str>> {
 ///
 /// [`wrap_iter`]: struct.Wrapper.html#method.wrap_iter
 /// [`into_wrap_iter`]: struct.Wrapper.html#method.into_wrap_iter
-pub fn wrap_iter<'s>(s: &'s str, width: usize) -> WrapIter<'s, HyphenSplitter> {
+pub fn wrap_iter<'s>(s: &'s str, width: usize) -> IntoWrapIter<'s, HyphenSplitter> {
     Wrapper::new(width).into_wrap_iter(s)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -454,15 +454,15 @@ impl<'w, 'a: 'w, S: WordSplitter> Wrapper<'a, S> {
     /// By changing the field, different hyphenation strategies can be
     /// implemented.
     ///
-    /// This method returns a [`WrapIterBorrow`] iterator of lines which
+    /// This method returns a [`WrapIter`] iterator of lines which
     /// borrows this `Wrapper`. If processed fully, it has an O(*n*)
     /// time and memory complexity where *n* is the input string length.
     ///
     /// [`self.splitter`]: #structfield.splitter
     /// [`WordSplitter`]: trait.WordSplitter.html
-    /// [`WrapIterBorrow`]: struct.WrapIterBorrow.html
-    pub fn wrap_iter(&'w self, s: &'a str) -> WrapIterBorrow<'w, 'a, S> {
-        WrapIterBorrow {
+    /// [`WrapIter`]: struct.WrapIter.html
+    pub fn wrap_iter(&'w self, s: &'a str) -> WrapIter<'w, 'a, S> {
+        WrapIter {
             wrapper: self,
             wrap_iter_impl: WrapIterImpl::new(self, s),
         }
@@ -493,19 +493,19 @@ impl<'a, S: WordSplitter> Iterator for IntoWrapIter<'a, S> {
 }
 
 /// An iterator over the lines of the input string which borrows a
-/// `Wrapper`. An instance of `WrapIterBorrow` is typically obtained
+/// `Wrapper`. An instance of `WrapIter` is typically obtained
 /// through the [`Wrapper::wrap_iter`] method.
 ///
 /// Each call of `.next()` method yields a line wrapped in `Some` if the
 /// input hasn't been fully processed yet. Otherwise it returns `None`.
 ///
 /// [`Wrapper::wrap_iter`]: struct.Wrapper.html#method.wrap_iter
-pub struct WrapIterBorrow<'w, 'a: 'w, S: WordSplitter + 'w> {
+pub struct WrapIter<'w, 'a: 'w, S: WordSplitter + 'w> {
     wrapper: &'w Wrapper<'a, S>,
     wrap_iter_impl: WrapIterImpl<'a>,
 }
 
-impl<'w, 'a: 'w, S: WordSplitter> Iterator for WrapIterBorrow<'w, 'a, S> {
+impl<'w, 'a: 'w, S: WordSplitter> Iterator for WrapIter<'w, 'a, S> {
     type Item = Cow<'a, str>;
 
     fn next(&mut self) -> Option<Cow<'a, str>> {


### PR DESCRIPTION
Before, we had three methods that would take a string and return an iterator with wrapped lines:

* `wrap_iter(&self, &str)`: cloned self
* `wrap_iter_borrow(&self, &str)`: borrowed self
* `into_wrap_iter(self, &str)`: consumed self

Here, the `wrap_iter_borrow` method is preferable to `wrap_iter` if the `Wrapper` outlives the iterator.

I think that will be the usual case, and that we can do without the method that cloned self -- if needed, the caller can get the functionality back by combining `clone` and `into_wrap_iter`:
```
wrapper.clone().into_wrap_iter(s)
```
We can then rename `wrap_iter_borrow` to just `wrap_iter` and thus make the method with the short name do "the right thing" by default.

The new method names are thus:

* `wrap_iter(&self, &str)`: borrows self
* `into_wrap_iter(self, &str)`: consumes self

This makes the names a little more aligned with the standard library where `Vec::iter(&self)` also borrows self while you iterate over the collection.