### PR TITLE
Use check-versions to guard against outdated README examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,12 @@ rust:
 cache: cargo
 
 script:
+  - |
+      if [[ "$TRAVIS_RUST_VERSION" =~ 1\.(8|13)\.0 ]]; then
+          echo "Old Rust, removing check-versions dependency"
+          sed -i "/^check-versions =/d" Cargo.toml
+          rm "tests/check-versions.rs"
+      fi
   - cargo build --verbose --features "$FEATURES"
   - cargo test --verbose --features "$FEATURES"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,4 @@ hyphenation = { version = "0.6.1", optional = true }
 [dev-dependencies]
 lipsum = "0.3"
 rand = "0.3"
+check-versions = "0.1"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If you would like to have automatic hyphenation, specify the
 dependency as:
 ```toml
 [dependencies]
-textwrap = { version: "0.8", features: ["hyphenation"] }
+textwrap = { version = "0.8", features = ["hyphenation"] }
 ```
 
 ## Documentation

--- a/tests/check-versions.rs
+++ b/tests/check-versions.rs
@@ -1,0 +1,7 @@
+#[macro_use]
+extern crate check_versions;
+
+#[test]
+fn test_readme_deps() {
+    assert_markdown_deps_updated!("README.md");
+}


### PR DESCRIPTION
My new crate [check-versions][1] makes it easy to prevent outdated TOML examples in the README. For both the 0.7.0 and 0.8.0 releases, I initially forgot to update the dependencies listed in the README when doing the release and I then had to redo the release tag.

[1]: https://github.com/mgeisler/check-versions