### PR TITLE
Use version-sync crate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,9 @@ cache: cargo
 script:
   - |
       if [[ "$TRAVIS_RUST_VERSION" =~ 1\.(8|13)\.0 ]]; then
-          echo "Old Rust, removing check-versions dependency"
-          sed -i "/^check-versions =/d" Cargo.toml
-          rm "tests/check-versions.rs"
+          echo "Old Rust detected, removing version-sync dependency"
+          sed -i "/^version-sync =/d" Cargo.toml
+          rm "tests/version-numbers.rs"
       fi
   - cargo build --verbose --features "$FEATURES"
   - cargo test --verbose --features "$FEATURES"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,4 +32,4 @@ hyphenation = { version = "0.6.1", optional = true }
 [dev-dependencies]
 lipsum = "0.3"
 rand = "0.3"
-check-versions = "0.1"
+version-sync = "0.1"

--- a/tests/version-numbers.rs
+++ b/tests/version-numbers.rs
@@ -1,5 +1,5 @@
 #[macro_use]
-extern crate check_versions;
+extern crate version_sync;
 
 #[test]
 fn test_readme_deps() {


### PR DESCRIPTION
My new [`version-sync`][1] crate makes it easy to keep the dependencies in `README.md` in sync with the crate version.

[1]: https://crates.io/crates/version-sync