### PR TITLE
emacs: define bug-reference-url-format

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,3 @@
+((nil
+  (bug-reference-bug-regexp . "#\\(?2:[0-9]+\\)")
+  (bug-reference-url-format . "https://github.com/mgeisler/textwrap/issues/%s")))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ readme = "README.md"
 keywords = ["text", "formatting", "wrap", "typesetting", "hyphenation"]
 categories = ["text-processing", "command-line-interface"]
 license = "MIT"
+exclude = [".dir-locals.el"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
This lets Emacs highlight issue numbers and link them back to the
GitHub repository.