### PR TITLE
travis: move version-sync removal to before_install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,16 @@ rust:
 
 cache: cargo
 
-script:
+before_install:
+  # We need Rust 1.15 or later for version-sync
   - |
       if [[ "$TRAVIS_RUST_VERSION" =~ 1\.(8|13)\.0 ]]; then
           echo "Old Rust detected, removing version-sync dependency"
           sed -i "/^version-sync =/d" Cargo.toml
           rm "tests/version-numbers.rs"
       fi
+
+script:
   - cargo build --verbose --features "$FEATURES"
   - cargo test --verbose --features "$FEATURES"
 


### PR DESCRIPTION
Having it in the script section worked fine, but it's more
semantically correct to remove the dev-dependency before we run the
install step.