### PR TITLE
tests: ensure html_root_url is in sync

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,4 +33,4 @@ hyphenation = { version = "0.6.1", optional = true }
 [dev-dependencies]
 lipsum = "0.3"
 rand = "0.3"
-version-sync = "0.1"
+version-sync = "0.2"

--- a/tests/version-numbers.rs
+++ b/tests/version-numbers.rs
@@ -5,3 +5,8 @@ extern crate version_sync;
 fn test_readme_deps() {
     assert_markdown_deps_updated!("README.md");
 }
+
+#[test]
+fn test_html_root_url() {
+    assert_html_root_url_updated!("src/lib.rs");
+}


### PR DESCRIPTION
The [version-sync][1] crate makes it easy to ensure that the `html_root_url` is in sync with crate version number.

[1]: https://github.com/mgeisler/version-sync