### PR TITLE
cargo: make term_size optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ appveyor = { repository = "mgeisler/textwrap" }
 
 [dependencies]
 unicode-width = "0.1.3"
-term_size = "0.3.0"
+term_size = { version = "0.3.0", optional = true }
 hyphenation = { version = "0.6.1", optional = true }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ dependency as:
 textwrap = { version = "0.8", features = ["hyphenation"] }
 ```
 
+To conveniently wrap text at the current terminal width, enable the
+`term_size` feature:
+
+```toml
+[dependencies]
+textwrap = { version = "0.8", features = ["term_size"] }
+```
+
 ## Documentation
 
 **[API documentation][api-docs]**
@@ -177,8 +185,18 @@ This section lists the largest changes per release.
 
 All public structs now implement `Debug`.
 
+The dependency on `term_size` is now optional, and by default this
+feature is not enabled. This is a *breaking change* for users of
+`Wrapper::with_termwidth`. Enable the `term_size` feature to restore
+the old functionality.
+
 Added a regression test for case where width is set to usize::MAX.
 Thanks @Fraser999!
+
+Issues closed:
+
+* Fixed [#101][issue-101]: Remove `term_size` as a (hard required)
+  dependency.
 
 ### Version 0.8.0 — September 4th, 2017
 
@@ -303,4 +321,5 @@ Contributions will be accepted under the same license.
 [issue-59]: ../../issues/59
 [issue-61]: ../../issues/61
 [issue-81]: ../../issues/81
+[issue-101]: ../../issues/101
 [mit]: LICENSE

--- a/README.md
+++ b/README.md
@@ -183,15 +183,13 @@ This section lists the largest changes per release.
 
 ### Unreleased
 
-All public structs now implement `Debug`.
-
 The dependency on `term_size` is now optional, and by default this
 feature is not enabled. This is a *breaking change* for users of
 `Wrapper::with_termwidth`. Enable the `term_size` feature to restore
 the old functionality.
 
 Added a regression test for case where width is set to usize::MAX.
-Thanks @Fraser999!
+Thanks @Fraser999! All public structs now implement `Debug`.
 
 Issues closed:
 

--- a/examples/termwidth.rs
+++ b/examples/termwidth.rs
@@ -1,14 +1,19 @@
+#[cfg(feature = "term_size")]
 extern crate textwrap;
 
-use textwrap::Wrapper;
+#[cfg(not(feature = "term_size"))]
+fn main() {
+    println!("Please enable the term_size feature to run this example.");
+}
 
+#[cfg(feature = "term_size")]
 fn main() {
     let example = "Memory safety without garbage collection. \
                    Concurrency without data races. \
                    Zero-cost abstractions.";
     // Create a new Wrapper -- automatically set the width to the
     // current terminal width.
-    let wrapper = Wrapper::with_termwidth();
+    let wrapper = textwrap::Wrapper::with_termwidth();
     println!("Formatted in within {} columns:", wrapper.width);
     println!("----");
     println!("{}", wrapper.fill(example));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@
 #![deny(missing_debug_implementations)]
 
 extern crate unicode_width;
+#[cfg(feature = "term_size")]
 extern crate term_size;
 #[cfg(feature = "hyphenation")]
 extern crate hyphenation;
@@ -266,6 +267,7 @@ impl<'a> Wrapper<'a, HyphenSplitter> {
     ///
     /// let wrapper = Wrapper::new(termwidth());
     /// ```
+    #[cfg(feature = "term_size")]
     pub fn with_termwidth() -> Wrapper<'a, HyphenSplitter> {
         Wrapper::new(termwidth())
     }
@@ -715,6 +717,7 @@ impl<'a> WrapIterImpl<'a> {
 ///     .initial_indent("  ")
 ///     .subsequent_indent("  ");
 /// ```
+#[cfg(feature = "term_size")]
 pub fn termwidth() -> usize {
     term_size::dimensions_stdout().map_or(80, |(w, _)| w)
 }


### PR DESCRIPTION
The term_size crate can be used to determine the current terminal
width and we included a trivial convenience wrapper around it.

However, term_size makes heavy use of unsafe Rust and this was a
concern to some users of textwrap. This commit makes the dependency a
non-default optional feature.

Fixes #101.