### PR TITLE
Re-enable compilation with term_size

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,9 +1,7 @@
 environment:
   matrix:
   - TOOLCHAIN: stable
-    FEATURES: "hyphenation"
   - TOOLCHAIN: nightly
-    FEATURES: "hyphenation"
 
 matrix:
   allow_failures:
@@ -15,10 +13,10 @@ install:
   - set PATH=%PATH%;%USERPROFILE%\.cargo\bin
 
 build_script:
-  - cargo build --verbose --features "%FEATURES%"
+  - cargo build --verbose --all-features
 
 test_script:
-  - cargo test --verbose --features "%FEATURES%"
+  - cargo test --verbose --all-features
 
 cache:
   - '%USERPROFILE%\.cargo'

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,13 +21,13 @@ script:
   - cargo test --verbose --features "$FEATURES"
 
 env:
-  - FEATURES=""
+  - FEATURES="term_size"
   - FEATURES="hyphenation"
 
 matrix:
   include:
     - rust: 1.8.0
-      env: FEATURES=""
+      env: FEATURES="term_size"
     - rust: 1.13.0
       env: FEATURES="hyphenation"
   allow_failures:


### PR DESCRIPTION
The code that relies on `term_size` is now optional, so this PR re-enables the feature so that this code gets compiled on Travis and AppVeyor.