### PR TITLE
WrapIterImpl: correctly reset in_whitespace flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,10 @@ This section lists the largest changes per release.
 Due to a change in the libc crate, the minimum version of Rust we test
 against is now 1.9.0.
 
+Issues closed:
+
+* Fixed [#99][issue-99]: Word broken even though it would fit on line.
+
 ### Version 0.9.0 — October 5th, 2017
 
 The dependency on `term_size` is now optional, and by default this
@@ -325,5 +329,6 @@ Contributions will be accepted under the same license.
 [issue-59]: https://github.com/mgeisler/textwrap/issues/59
 [issue-61]: https://github.com/mgeisler/textwrap/issues/61
 [issue-81]: https://github.com/mgeisler/textwrap/issues/81
+[issue-99]: https://github.com/mgeisler/textwrap/issues/99
 [issue-101]: https://github.com/mgeisler/textwrap/issues/101
 [mit]: LICENSE

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -634,6 +634,7 @@ impl<'a> WrapIterImpl<'a> {
             } else if self.line_width + char_width > wrapper.width {
                 // There is no room for this character on the current
                 // line. Try to split the final word.
+                self.in_whitespace = false;
                 let remaining_text = &self.source[self.split + self.split_len..];
                 let final_word = match remaining_text
                           .find(|ch: char| ch.is_whitespace() && ch != NBSP) {
@@ -978,6 +979,14 @@ mod tests {
         // column zero and is not indented. The line before might end
         // up with trailing whitespace.
         assert_eq!(wrap("foo               bar", 5), vec!["foo", "bar"]);
+    }
+
+    #[test]
+    fn test_issue_99() {
+        // We did not reset the in_whitespace flag correctly and did
+        // not handle single-character words after a line break.
+        assert_eq!(wrap("aaabbbccc x yyyzzzwww", 9),
+                   vec!["aaabbbccc", "x", "yyyzzzwww"]);
     }
 
     #[test]


### PR DESCRIPTION
We did not reset the in_whitespace flag immediately when seeing a
non-whitespace character. This meant that single character words could
be split incorrectly.

Fixes #99.