### PR TITLE
travis: bump minimum Rust version to 1.9.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ cache: cargo
 before_install:
   # We need Rust 1.15 or later for version-sync
   - |
-      if [[ "$TRAVIS_RUST_VERSION" =~ 1\.(8|13)\.0 ]]; then
+      if [[ "$TRAVIS_RUST_VERSION" =~ 1\.(9|13)\.0 ]]; then
           echo "Old Rust detected, removing version-sync dependency"
           sed -i "/^version-sync =/d" Cargo.toml
           rm "tests/version-numbers.rs"
@@ -26,7 +26,7 @@ env:
 
 matrix:
   include:
-    - rust: 1.8.0
+    - rust: 1.9.0
       env: FEATURES="term_size"
     - rust: 1.13.0
       env: FEATURES="hyphenation"

--- a/README.md
+++ b/README.md
@@ -181,6 +181,11 @@ cost abstractions.
 
 This section lists the largest changes per release.
 
+### Unreleased
+
+Due to a change in the libc crate, the minimum version of Rust we test
+against is now 1.9.0.
+
 ### Version 0.9.0 — October 5th, 2017
 
 The dependency on `term_size` is now optional, and by default this


### PR DESCRIPTION
This is due to our transitive dependency on the libc crate, which
started to use "#[deprecated(...)]" in version 0.2.34.