### PR TITLE
WrapIterImpl: take split_len into account when hyphenating

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ against is now 1.9.0.
 Issues closed:
 
 * Fixed [#99][issue-99]: Word broken even though it would fit on line.
+* Fixed [#107][issue-107]: Automatic hyphenation is off by one.
 
 ### Version 0.9.0 — October 5th, 2017
 
@@ -331,4 +332,5 @@ Contributions will be accepted under the same license.
 [issue-81]: https://github.com/mgeisler/textwrap/issues/81
 [issue-99]: https://github.com/mgeisler/textwrap/issues/99
 [issue-101]: https://github.com/mgeisler/textwrap/issues/101
+[issue-107]: https://github.com/mgeisler/textwrap/issues/107
 [mit]: LICENSE

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -625,7 +625,10 @@ impl<'a> WrapIterImpl<'a> {
                 let splits = wrapper.splitter.split(final_word);
                 for &(head, hyp, _) in splits.iter().rev() {
                     if self.line_width_at_split + head.width() + hyp.width() <= wrapper.width {
-                        self.split += head.len();
+                        // We can fit head into the current line.
+                        // Advance the split point by the width of the
+                        // whitespace and the head length.
+                        self.split += self.split_len + head.len();
                         self.split_len = 0;
                         hyphen = hyp;
                         break;
@@ -1064,6 +1067,17 @@ mod tests {
         let wrapper = Wrapper::with_splitter(10, corpus);
         assert_eq!(wrapper.wrap("Internationalization"),
                    vec!["Interna-", "tionaliza-", "tion"]);
+    }
+
+    #[test]
+    #[cfg(feature = "hyphenation")]
+    fn split_len_hyphenation() {
+        // Test that hyphenation takes the width of the wihtespace
+        // into account.
+        let corpus = hyphenation::load(Language::English_US).unwrap();
+        let wrapper = Wrapper::with_splitter(15, corpus);
+        assert_eq!(wrapper.wrap("garbage   collection"),
+                   vec!["garbage   col-", "lection"]);
     }
 
     #[test]


### PR DESCRIPTION
Before we did not take the width of the split into account when
hyphenating a word. This meant that all hyphenation was off by the
width of the whitespace (typically off by one when the split point was
a single space).

This has been broken since 4313d58 where I rewrote the splitting
algorithm to use Vec<Cow<str>> instead of Vec<String>. There is now a
test for this case.

Fixes #107.