### PR TITLE
Improve docstrings for indent and dedent functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -824,14 +824,21 @@ pub fn indent(s: &str, prefix: &str) -> String {
 
 /// Removes common leading whitespace from each line.
 ///
-/// This will look at each non-empty line and determine the maximum
-/// amount of whitespace that can be removed from the line.
+/// This function will look at each non-empty line and determine the
+/// maximum amount of whitespace that can be removed from all lines:
 ///
 /// ```
 /// use textwrap::dedent;
 ///
-/// assert_eq!(dedent("  1st line\n  2nd line\n"),
-///            "1st line\n2nd line\n");
+/// assert_eq!(dedent("
+///     1st line
+///       2nd line
+///     3rd line
+/// "), "
+/// 1st line
+///   2nd line
+/// 3rd line
+/// ");
 /// ```
 pub fn dedent(s: &str) -> String {
     let mut prefix = String::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -789,7 +789,13 @@ pub fn wrap_iter(s: &str, width: usize) -> IntoWrapIter<HyphenSplitter> {
 /// ```
 /// use textwrap::indent;
 ///
-/// assert_eq!(indent("Foo\nBar\n", "  "), "  Foo\n  Bar\n");
+/// assert_eq!(indent("
+/// Foo
+/// Bar
+/// ", "  "), "
+///   Foo
+///   Bar
+/// ");
 /// ```
 ///
 /// Empty lines (lines consisting only of whitespace) are not indented
@@ -798,8 +804,19 @@ pub fn wrap_iter(s: &str, width: usize) -> IntoWrapIter<HyphenSplitter> {
 /// ```
 /// use textwrap::indent;
 ///
-/// assert_eq!(indent("Foo\n\nBar\n  \t  \nBaz\n", "  "),
-///            "  Foo\n\n  Bar\n\n  Baz\n");
+/// assert_eq!(indent("
+/// Foo
+///
+/// Bar
+///   \t
+/// Baz
+/// ", "->"), "
+/// ->Foo
+///
+/// ->Bar
+///
+/// ->Baz
+/// ");
 /// ```
 ///
 /// Leading and trailing whitespace on non-empty lines is kept
@@ -808,7 +825,7 @@ pub fn wrap_iter(s: &str, width: usize) -> IntoWrapIter<HyphenSplitter> {
 /// ```
 /// use textwrap::indent;
 ///
-/// assert_eq!(indent(" \t  Foo   ", "  "), "   \t  Foo   \n");
+/// assert_eq!(indent(" \t  Foo   ", "->"), "-> \t  Foo   \n");
 /// ```
 pub fn indent(s: &str, prefix: &str) -> String {
     let mut result = String::new();


### PR DESCRIPTION
This rewrites the docstring examples so they use multi-line strings instead of using embedded `\n` characters. This kind of formatting might not be completely `rustfmt` compliant, but it shows the indentation better.