### PR TITLE
Bump minimum supported Rust version to 1.17.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,9 @@ rust:
   - stable
   - beta
   - nightly
+  - 1.17.0
 
 cache: cargo
-
-before_install:
-  # We need Rust 1.15 or later for version-sync
-  - |
-      if [[ "$TRAVIS_RUST_VERSION" =~ 1\.(9|13)\.0 ]]; then
-          echo "Old Rust detected, removing version-sync dependency"
-          sed -i "/^version-sync =/d" Cargo.toml
-          rm "tests/version-numbers.rs"
-      fi
 
 script:
   - cargo build --verbose --features "$FEATURES"
@@ -25,10 +17,5 @@ env:
   - FEATURES="hyphenation"
 
 matrix:
-  include:
-    - rust: 1.9.0
-      env: FEATURES="term_size"
-    - rust: 1.13.0
-      env: FEATURES="hyphenation"
   allow_failures:
     - rust: nightly

--- a/README.md
+++ b/README.md
@@ -183,8 +183,8 @@ This section lists the largest changes per release.
 
 ### Unreleased
 
-Due to a change in the libc crate, the minimum version of Rust we test
-against is now 1.9.0.
+Due to our dependencies bumping their minimum supported version of
+Rust, the minimum version of Rust we test against is now 1.17.0.
 
 Issues closed:
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,22 +192,6 @@ impl WordSplitter for Corpus {
     }
 }
 
-/// Backport of the `AddAssign` trait implementation from Rust 1.14.
-fn cow_add_assign<'a>(lhs: &mut Cow<'a, str>, rhs: &'a str) {
-    if lhs.is_empty() {
-        *lhs = Cow::Borrowed(rhs)
-    } else if rhs.is_empty() {
-        return;
-    } else {
-        if let Cow::Borrowed(inner) = *lhs {
-            let mut s = String::with_capacity(lhs.len() + rhs.len());
-            s.push_str(inner);
-            *lhs = Cow::Owned(s);
-        }
-        lhs.to_mut().push_str(rhs);
-    }
-}
-
 
 /// A Wrapper holds settings for wrapping and filling text. Use it
 /// when the convenience [`wrap_iter`], [`wrap`] and [`fill`] functions
@@ -653,8 +637,8 @@ impl<'a> WrapIterImpl<'a> {
 
                 if self.start < self.split {
                     let mut line = self.create_result_line(wrapper);
-                    cow_add_assign(&mut line, &self.source[self.start..self.split]);
-                    cow_add_assign(&mut line, hyphen);
+                    line += &self.source[self.start..self.split];
+                    line += hyphen;
 
                     self.start = self.split + self.split_len;
                     self.line_width += wrapper.subsequent_indent.width();
@@ -674,7 +658,7 @@ impl<'a> WrapIterImpl<'a> {
         // Add final line.
         if self.start < self.source.len() {
             let mut line = self.create_result_line(wrapper);
-            cow_add_assign(&mut line, &self.source[self.start..]);
+            line += &self.source[self.start..];
             return Some(line);
         }
 


### PR DESCRIPTION
One of our dependencies bumped the minimum supported version of Rust
to 1.17.0 and even though we did not change anything, our builds
started failing.

We could try to find the troublesome dependency and pin it down, but
it seems that the general attitude towards version bumps of the
compiler is to simply support the latest two or three stable releases.
Rust 1.24 will be released later this week, so we still offer much
better support than most other libraries.