### PR TITLE
cargo: bump rand dev-dependency to latest version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,5 +32,5 @@ hyphenation = { version = "0.6.1", optional = true }
 
 [dev-dependencies]
 lipsum = "0.4"
-rand = "0.3"
+rand = "0.4"
 version-sync = "0.5"


### PR DESCRIPTION
Since we're now using Rust 1.17 or later, we can start using the
latest version of rand for our tests.