### PR TITLE
Add example that shows how newlines are preserved when wrapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ Issues closed:
 
 * Fixed [#99][issue-99]: Word broken even though it would fit on line.
 * Fixed [#107][issue-107]: Automatic hyphenation is off by one.
+* Fixed [#122][issue-122]: Take newlines into account when wrapping.
 
 ### Version 0.9.0 — October 5th, 2017
 
@@ -333,4 +334,5 @@ Contributions will be accepted under the same license.
 [issue-99]: https://github.com/mgeisler/textwrap/issues/99
 [issue-101]: https://github.com/mgeisler/textwrap/issues/101
 [issue-107]: https://github.com/mgeisler/textwrap/issues/107
+[issue-122]: https://github.com/mgeisler/textwrap/issues/122
 [mit]: LICENSE

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -386,6 +386,19 @@ impl<'w, 'a: 'w, S: WordSplitter> Wrapper<'a, S> {
     ///            vec!["Concurrency without",
     ///                 "data races."]);
     /// ```
+    ///
+    /// Notice that newlines in the input are preserved. This means
+    /// that they force a line break, regardless of how long the
+    /// current line is:
+    ///
+    /// ```
+    /// use textwrap::Wrapper;
+    ///
+    /// let wrapper = Wrapper::new(40);
+    /// assert_eq!(wrapper.wrap("First line.\nSecond line."),
+    ///            vec!["First line.", "Second line."]);
+    /// ```
+    ///
     pub fn wrap(&self, s: &'a str) -> Vec<Cow<'a, str>> {
         self.wrap_iter(s).collect::<Vec<_>>()
     }


### PR DESCRIPTION
This is a little bit of documentation for #122.