### PR TITLE
Added support for custom width providers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -707,7 +707,7 @@ impl<'a> WrapIterImpl<'a> {
                     line += &self.source[self.start..self.split];
 
                     self.start = self.split + self.split_len;
-                    self.line_width = wrapper.subsequent_indent.width();
+                    self.line_width = width_provider_str(wrapper.subsequent_indent, width_provider);
 
                     return Some(line);
                 }
@@ -767,7 +767,7 @@ impl<'a> WrapIterImpl<'a> {
                     line += hyphen;
 
                     self.start = self.split + self.split_len;
-                    self.line_width += wrapper.subsequent_indent.width();
+                    self.line_width += width_provider_str(wrapper.subsequent_indent, width_provider);
                     self.line_width -= self.line_width_at_split;
                     self.line_width += char_width;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,6 @@ extern crate hyphenation;
 use std::borrow::Cow;
 use std::str::CharIndices;
 
-use unicode_width::UnicodeWidthStr;
 pub use unicode_width::UnicodeWidthChar;
 #[cfg(feature = "hyphenation")]
 use hyphenation::{Corpus, Hyphenation};


### PR DESCRIPTION
This is part of the ongoing effort to support #126
This PR offers a way to set custom (integer) widths for characters. It does not add support for floating point numbers yet.
This allows the user to pass to most functions a closure taking a ``char`` and returning its width as a ``usize``.
I tried to limit API changes for simple tasks by leaving the ``fill`` and ``wrap`` functions intact in signature, and added ``wrap_dynamic`` and ``fill_dynamic`` that take the closure.
I was not really inspired with those names, if you want me to change them to something else I would be glad to do it.
I also chose to re-export ``unicode_width::UnicodeWidthChar`` as it will probably come in handy for people writing custom closures, avoiding them to depend on ``unicode_width``.

Example:
```rust
let wrap = Wrapper::new(15);
let res = wrap.wrap_dynamic("Concurrency without data races.", |c| {
    if c == 'h' {
        c.width().unwrap_or(0) + 4
    } else {
        c.width().unwrap_or(0)
    }
});
assert_eq!(res, vec!["Concurrency", "without", "data races."]);
```
This example illustrates an hypothetical case where an h would actually take 5 columns instead of 1.
I included it as a test, with its equivalent for ``Wrapper::fill_dynamic``.

Benchmark:
```
before
test fill_100 ... bench:         539 ns/iter (+/- 115)
test fill_200 ... bench:       1,188 ns/iter (+/- 141)
test fill_400 ... bench:       2,416 ns/iter (+/- 329)
test fill_800 ... bench:       5,349 ns/iter (+/- 974)
test wrap_100 ... bench:         639 ns/iter (+/- 111)
test wrap_200 ... bench:       1,397 ns/iter (+/- 206)
test wrap_400 ... bench:       2,729 ns/iter (+/- 405)
test wrap_800 ... bench:       5,575 ns/iter (+/- 664)

after
test fill_100 ... bench:         554 ns/iter (+/- 139)
test fill_200 ... bench:       1,199 ns/iter (+/- 145)
test fill_400 ... bench:       2,409 ns/iter (+/- 1,570)
test fill_800 ... bench:       5,142 ns/iter (+/- 658)
test wrap_100 ... bench:         632 ns/iter (+/- 113)
test wrap_200 ... bench:       1,430 ns/iter (+/- 221)
test wrap_400 ... bench:       2,732 ns/iter (+/- 323)
test wrap_800 ... bench:       5,417 ns/iter (+/- 456)
```

Zero-cost abstraction really is awesome.