### PR TITLE
Add test for #129

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ Issues closed:
 * Fixed [#99][issue-99]: Word broken even though it would fit on line.
 * Fixed [#107][issue-107]: Automatic hyphenation is off by one.
 * Fixed [#122][issue-122]: Take newlines into account when wrapping.
+* Fixed [#129][issue-129]: Panic on string with em-dash.
 
 ### Version 0.9.0 — October 5th, 2017
 
@@ -335,4 +336,5 @@ Contributions will be accepted under the same license.
 [issue-101]: https://github.com/mgeisler/textwrap/issues/101
 [issue-107]: https://github.com/mgeisler/textwrap/issues/107
 [issue-122]: https://github.com/mgeisler/textwrap/issues/122
+[issue-129]: https://github.com/mgeisler/textwrap/issues/129
 [mit]: LICENSE

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1000,7 +1000,7 @@ mod tests {
     }
 
     #[test]
-    fn test_issue_99() {
+    fn issue_99() {
         // We did not reset the in_whitespace flag correctly and did
         // not handle single-character words after a line break.
         assert_eq!(wrap("aaabbbccc x yyyzzzwww", 9),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1008,6 +1008,13 @@ mod tests {
     }
 
     #[test]
+    fn issue_129() {
+        // The dash is an em-dash which takes up four bytes. We used
+        // to panic since we tried to index into the character.
+        assert_eq!(wrap("x – x", 1), vec!["x", "–", "x"]);
+    }
+
+    #[test]
     fn wide_character_handling() {
         assert_eq!(wrap("Hello, World!", 15), vec!["Hello, World!"]);
         assert_eq!(wrap("Ｈｅｌｌｏ, Ｗｏｒｌｄ!", 15),


### PR DESCRIPTION
Thanks to @rkday for supplying the initial test case in #129.