### PR TITLE
rustfmt: use default configuration

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,8 +1,0 @@
-array_layout = "Visual"
-control_style = "Legacy"
-fn_args_layout = "Visual"
-fn_call_style = "Visual"
-generics_indent = "Visual"
-struct_lit_width = 40
-reorder_imports_in_group = true
-reorder_imported_names = true

--- a/benches/linear.rs
+++ b/benches/linear.rs
@@ -3,20 +3,20 @@
 // The benchmarks here verify that the complexity grows as O(*n*)
 // where *n* is the number of characters in the text to be wrapped.
 
-extern crate test;
-extern crate rand;
-extern crate lipsum;
-extern crate textwrap;
 #[cfg(feature = "hyphenation")]
 extern crate hyphenation;
+extern crate lipsum;
+extern crate rand;
+extern crate test;
+extern crate textwrap;
 
-use test::Bencher;
 #[cfg(feature = "hyphenation")]
 use hyphenation::Language;
+use lipsum::MarkovChain;
+use rand::XorShiftRng;
+use test::Bencher;
 #[cfg(feature = "hyphenation")]
 use textwrap::Wrapper;
-use rand::XorShiftRng;
-use lipsum::MarkovChain;
 
 const LINE_LENGTH: usize = 60;
 
@@ -59,7 +59,6 @@ fn fill_800(b: &mut Bencher) {
     b.iter(|| textwrap::fill(text, LINE_LENGTH))
 }
 
-
 #[bench]
 fn wrap_100(b: &mut Bencher) {
     let text = &lorem_ipsum(100);
@@ -83,7 +82,6 @@ fn wrap_800(b: &mut Bencher) {
     let text = &lorem_ipsum(800);
     b.iter(|| textwrap::wrap(text, LINE_LENGTH))
 }
-
 
 #[bench]
 #[cfg(feature = "hyphenation")]

--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -6,7 +6,6 @@ extern crate textwrap;
 use hyphenation::Language;
 use textwrap::Wrapper;
 
-
 #[cfg(not(feature = "hyphenation"))]
 fn new_wrapper<'a>() -> Wrapper<'a, textwrap::HyphenSplitter> {
     Wrapper::new(0)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,19 +45,19 @@
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
 
-extern crate unicode_width;
-#[cfg(feature = "term_size")]
-extern crate term_size;
 #[cfg(feature = "hyphenation")]
 extern crate hyphenation;
+#[cfg(feature = "term_size")]
+extern crate term_size;
+extern crate unicode_width;
 
 use std::borrow::Cow;
 use std::str::CharIndices;
 
-use unicode_width::UnicodeWidthStr;
-use unicode_width::UnicodeWidthChar;
 #[cfg(feature = "hyphenation")]
 use hyphenation::{Corpus, Hyphenation};
+use unicode_width::UnicodeWidthChar;
+use unicode_width::UnicodeWidthStr;
 
 /// A non-breaking space.
 const NBSP: char = '\u{a0}';
@@ -192,7 +192,6 @@ impl WordSplitter for Corpus {
     }
 }
 
-
 /// A Wrapper holds settings for wrapping and filling text. Use it
 /// when the convenience [`wrap_iter`], [`wrap`] and [`fill`] functions
 /// are not flexible enough.
@@ -289,7 +288,10 @@ impl<'w, 'a: 'w, S: WordSplitter> Wrapper<'a, S> {
     ///
     /// [`self.initial_indent`]: #structfield.initial_indent
     pub fn initial_indent(self, indent: &'a str) -> Wrapper<'a, S> {
-        Wrapper { initial_indent: indent, ..self }
+        Wrapper {
+            initial_indent: indent,
+            ..self
+        }
     }
 
     /// Change [`self.subsequent_indent`]. The subsequent indentation
@@ -311,7 +313,10 @@ impl<'w, 'a: 'w, S: WordSplitter> Wrapper<'a, S> {
     ///
     /// [`self.subsequent_indent`]: #structfield.subsequent_indent
     pub fn subsequent_indent(self, indent: &'a str) -> Wrapper<'a, S> {
-        Wrapper { subsequent_indent: indent, ..self }
+        Wrapper {
+            subsequent_indent: indent,
+            ..self
+        }
     }
 
     /// Change [`self.break_words`]. This controls if words longer
@@ -320,7 +325,10 @@ impl<'w, 'a: 'w, S: WordSplitter> Wrapper<'a, S> {
     ///
     /// [`self.break_words`]: #structfield.break_words
     pub fn break_words(self, setting: bool) -> Wrapper<'a, S> {
-        Wrapper { break_words: setting, ..self }
+        Wrapper {
+            break_words: setting,
+            ..self
+        }
     }
 
     /// Fill a line of text at `self.width` characters. Strings are
@@ -488,10 +496,12 @@ impl<'w, 'a: 'w, S: WordSplitter> Wrapper<'a, S> {
     pub fn into_wrap_iter(self, s: &'a str) -> IntoWrapIter<'a, S> {
         let inner = WrapIterImpl::new(&self, s);
 
-        IntoWrapIter { wrapper: self, inner: inner }
+        IntoWrapIter {
+            wrapper: self,
+            inner: inner,
+        }
     }
 }
-
 
 /// An iterator over the lines of the input string which owns a
 /// `Wrapper`. An instance of `IntoWrapIter` is typically obtained
@@ -696,7 +706,6 @@ impl<'a> WrapIterImpl<'a> {
         None
     }
 }
-
 
 /// Return the current terminal width. If the terminal width cannot be
 /// determined (typically because the standard output is not connected
@@ -935,9 +944,9 @@ mod tests {
     #[cfg(feature = "hyphenation")]
     extern crate hyphenation;
 
+    use super::*;
     #[cfg(feature = "hyphenation")]
     use hyphenation::Language;
-    use super::*;
 
     /// Add newlines. Ensures that the final line in the vector also
     /// has a newline.
@@ -1003,8 +1012,10 @@ mod tests {
     fn issue_99() {
         // We did not reset the in_whitespace flag correctly and did
         // not handle single-character words after a line break.
-        assert_eq!(wrap("aaabbbccc x yyyzzzwww", 9),
-                   vec!["aaabbbccc", "x", "yyyzzzwww"]);
+        assert_eq!(
+            wrap("aaabbbccc x yyyzzzwww", 9),
+            vec!["aaabbbccc", "x", "yyyzzzwww"]
+        );
     }
 
     #[test]
@@ -1017,8 +1028,10 @@ mod tests {
     #[test]
     fn wide_character_handling() {
         assert_eq!(wrap("Hello, World!", 15), vec!["Hello, World!"]);
-        assert_eq!(wrap("Ｈｅｌｌｏ, Ｗｏｒｌｄ!", 15),
-                   vec!["Ｈｅｌｌｏ,", "Ｗｏｒｌｄ!"]);
+        assert_eq!(
+            wrap("Ｈｅｌｌｏ, Ｗｏｒｌｄ!", 15),
+            vec!["Ｈｅｌｌｏ,", "Ｗｏｒｌｄ!"]
+        );
     }
 
     #[test]
@@ -1064,8 +1077,10 @@ mod tests {
     #[test]
     fn hyphens_flag() {
         let wrapper = Wrapper::new(5).break_words(false);
-        assert_eq!(wrapper.wrap("The --foo-bar flag."),
-                   vec!["The", "--foo-", "bar", "flag."]);
+        assert_eq!(
+            wrapper.wrap("The --foo-bar flag."),
+            vec!["The", "--foo-", "bar", "flag."]
+        );
     }
 
     #[test]
@@ -1107,12 +1122,16 @@ mod tests {
     fn auto_hyphenation() {
         let corpus = hyphenation::load(Language::English_US).unwrap();
         let wrapper = Wrapper::new(10);
-        assert_eq!(wrapper.wrap("Internationalization"),
-                   vec!["Internatio", "nalization"]);
+        assert_eq!(
+            wrapper.wrap("Internationalization"),
+            vec!["Internatio", "nalization"]
+        );
 
         let wrapper = Wrapper::with_splitter(10, corpus);
-        assert_eq!(wrapper.wrap("Internationalization"),
-                   vec!["Interna-", "tionaliza-", "tion"]);
+        assert_eq!(
+            wrapper.wrap("Internationalization"),
+            vec!["Interna-", "tionaliza-", "tion"]
+        );
     }
 
     #[test]
@@ -1122,8 +1141,10 @@ mod tests {
         // into account.
         let corpus = hyphenation::load(Language::English_US).unwrap();
         let wrapper = Wrapper::with_splitter(15, corpus);
-        assert_eq!(wrapper.wrap("garbage   collection"),
-                   vec!["garbage   col-", "lection"]);
+        assert_eq!(
+            wrapper.wrap("garbage   collection"),
+            vec!["garbage   col-", "lection"]
+        );
     }
 
     #[test]
@@ -1154,8 +1175,10 @@ mod tests {
         assert_eq!(wrapper.wrap("over-caffinated"), vec!["over-", "caffinated"]);
 
         let wrapper = Wrapper::with_splitter(8, corpus).break_words(false);
-        assert_eq!(wrapper.wrap("over-caffinated"),
-                   vec!["over-", "caffi-", "nated"]);
+        assert_eq!(
+            wrapper.wrap("over-caffinated"),
+            vec!["over-", "caffi-", "nated"]
+        );
     }
 
     #[test]


### PR DESCRIPTION
With the rustfmt-preview component, most of the old settings stopped
taking effect. Instead of configuring the new version of rustfmt, it
seems easier to go with the defaults.