### PR TITLE
travis: turn cache off for coverage build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ matrix:
   include:
     - rust: stable
       sudo: required
+      cache: off
       env: []
       script:
         - bash <(curl -s https://raw.githubusercontent.com/xd009642/tarpaulin/master/travis-install.sh)


### PR DESCRIPTION
The 'cargo tarpaulin' command clear the cache on startup.