### PR TITLE
circleci: generate coverage report

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,13 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: xd009642/tarpaulin
+    steps:
+      - checkout
+      - run:
+          name: Generate coverage report
+          command: cargo tarpaulin --out Xml --features 'term_size hyphenation'
+      - run:
+          name: Upload to codecov.io
+          command: bash <(curl -s https://codecov.io/bash) -Z -f cobertura.xml

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,3 +4,10 @@ codecov:
   ci:
     - !appveyor
     - !travis
+
+coverage:
+  status:
+    project:
+      default:
+        # Allow a 5% drop in overall project coverage on a PR.
+        threshold: 5%

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,6 @@
+codecov:
+  # Do not wait for these CI providers since they will not upload any
+  # coverage reports.
+  ci:
+    - !appveyor
+    - !travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,15 +17,5 @@ script:
   - cargo test --verbose --features "$FEATURES"
 
 matrix:
-  include:
-    - rust: stable
-      sudo: required
-      cache: off
-      env: []
-      script:
-        - bash <(curl -s https://raw.githubusercontent.com/xd009642/tarpaulin/master/travis-install.sh)
-        - cargo tarpaulin --features 'term_size hyphenation' --out Xml
-        - bash <(curl -s https://codecov.io/bash) -Z -f cobertura.xml
-
   allow_failures:
     - rust: nightly


### PR DESCRIPTION
This moves the coverage generation from Travis CI to CircleCI.

On Travis CI, this job would start last and thus make the build time
longer -- with CircleCI, we now have four extra Docker containers at
our disposal. They start significantly faster than the Google Compute
Engine instances used by Travis CI, which further helps to ensure a
quick turn around on the builds.