### PR TITLE
travis: bump minimum version of Rust to 1.21

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rust:
   - stable
   - beta
   - nightly
-  - 1.17.0
+  - 1.21.0
 
 cache: cargo
 

--- a/README.md
+++ b/README.md
@@ -182,6 +182,11 @@ cost abstractions.
 
 This section lists the largest changes per release.
 
+### Unreleased
+
+Due to our dependencies bumping their minimum supported version of
+Rust, the minimum version of Rust we test against is now 1.21.0.
+
 ### Version 0.10.0 — April 28th, 2018
 
 Due to our dependencies bumping their minimum supported version of


### PR DESCRIPTION
This is due to unicode-normalization version 0.1.7.