### PR TITLE
Update `hyphenation` to 0.7.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ codecov = { repository = "mgeisler/textwrap" }
 [dependencies]
 unicode-width = "0.1.3"
 term_size = { version = "0.3.0", optional = true }
-hyphenation = { version = "0.6.1", optional = true }
+hyphenation = { version = "0.7.1", optional = true, features = ["embed_all"] }
 
 [dev-dependencies]
 lipsum = "0.5"

--- a/README.md
+++ b/README.md
@@ -69,12 +69,12 @@ configure the hyphenation patterns to use:
 extern crate hyphenation;
 extern crate textwrap;
 
-use hyphenation::Language;
+use hyphenation::{Language, Load, Standard};
 use textwrap::Wrapper;
 
 fn main() {
-    let corpus = hyphenation::load(Language::English_US).unwrap();
-    let wrapper = Wrapper::with_splitter(18, corpus);
+    let hyphenator = Standard::from_embedded(Language::EnglishUS).unwrap();
+    let wrapper = Wrapper::with_splitter(18, hyphenator);
     let text = "textwrap: a small library for wrapping text.";
     println!("{}", wrapper.fill(text))
 }

--- a/benches/linear.rs
+++ b/benches/linear.rs
@@ -11,7 +11,7 @@ extern crate test;
 extern crate textwrap;
 
 #[cfg(feature = "hyphenation")]
-use hyphenation::Language;
+use hyphenation::{Language, Load, Standard};
 use lipsum::MarkovChain;
 use rand::XorShiftRng;
 use test::Bencher;
@@ -87,8 +87,8 @@ fn wrap_800(b: &mut Bencher) {
 #[cfg(feature = "hyphenation")]
 fn hyphenation_fill_100(b: &mut Bencher) {
     let text = &lorem_ipsum(100);
-    let corpus = hyphenation::load(Language::Latin).unwrap();
-    let wrapper = Wrapper::with_splitter(LINE_LENGTH, corpus);
+    let dictionary = Standard::from_embedded(Language::Latin).unwrap();
+    let wrapper = Wrapper::with_splitter(LINE_LENGTH, dictionary);
     b.iter(|| wrapper.fill(text))
 }
 
@@ -96,8 +96,8 @@ fn hyphenation_fill_100(b: &mut Bencher) {
 #[cfg(feature = "hyphenation")]
 fn hyphenation_fill_200(b: &mut Bencher) {
     let text = &lorem_ipsum(200);
-    let corpus = hyphenation::load(Language::Latin).unwrap();
-    let wrapper = Wrapper::with_splitter(LINE_LENGTH, corpus);
+    let dictionary = Standard::from_embedded(Language::Latin).unwrap();
+    let wrapper = Wrapper::with_splitter(LINE_LENGTH, dictionary);
     b.iter(|| wrapper.fill(text))
 }
 
@@ -105,8 +105,8 @@ fn hyphenation_fill_200(b: &mut Bencher) {
 #[cfg(feature = "hyphenation")]
 fn hyphenation_fill_400(b: &mut Bencher) {
     let text = &lorem_ipsum(400);
-    let corpus = hyphenation::load(Language::Latin).unwrap();
-    let wrapper = Wrapper::with_splitter(LINE_LENGTH, corpus);
+    let dictionary = Standard::from_embedded(Language::Latin).unwrap();
+    let wrapper = Wrapper::with_splitter(LINE_LENGTH, dictionary);
     b.iter(|| wrapper.fill(text))
 }
 
@@ -114,7 +114,7 @@ fn hyphenation_fill_400(b: &mut Bencher) {
 #[cfg(feature = "hyphenation")]
 fn hyphenation_fill_800(b: &mut Bencher) {
     let text = &lorem_ipsum(800);
-    let corpus = hyphenation::load(Language::Latin).unwrap();
-    let wrapper = Wrapper::with_splitter(LINE_LENGTH, corpus);
+    let dictionary = Standard::from_embedded(Language::Latin).unwrap();
+    let wrapper = Wrapper::with_splitter(LINE_LENGTH, dictionary);
     b.iter(|| wrapper.fill(text))
 }

--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -3,7 +3,7 @@ extern crate hyphenation;
 extern crate textwrap;
 
 #[cfg(feature = "hyphenation")]
-use hyphenation::Language;
+use hyphenation::{Language, Load};
 use textwrap::Wrapper;
 
 #[cfg(not(feature = "hyphenation"))]
@@ -12,9 +12,9 @@ fn new_wrapper<'a>() -> Wrapper<'a, textwrap::HyphenSplitter> {
 }
 
 #[cfg(feature = "hyphenation")]
-fn new_wrapper<'a>() -> Wrapper<'a, hyphenation::Corpus> {
-    let corpus = hyphenation::load(Language::English_US).unwrap();
-    Wrapper::with_splitter(0, corpus)
+fn new_wrapper<'a>() -> Wrapper<'a, hyphenation::Standard> {
+    let dictionary = hyphenation::Standard::from_embedded(Language::EnglishUS).unwrap();
+    Wrapper::with_splitter(0, dictionary)
 }
 
 fn main() {

--- a/examples/termwidth.rs
+++ b/examples/termwidth.rs
@@ -3,7 +3,7 @@ extern crate hyphenation;
 extern crate textwrap;
 
 #[cfg(feature = "hyphenation")]
-use hyphenation::Language;
+use hyphenation::{Language, Load, Standard};
 use textwrap::Wrapper;
 
 #[cfg(not(feature = "term_size"))]
@@ -19,9 +19,9 @@ fn main() {
     }
 
     #[cfg(feature = "hyphenation")]
-    fn new_wrapper<'a>() -> (&'static str, Wrapper<'a, hyphenation::Corpus>) {
-        let corpus = hyphenation::load(Language::English_US).unwrap();
-        ("with hyphenation", Wrapper::with_splitter(textwrap::termwidth(), corpus))
+    fn new_wrapper<'a>() -> (&'static str, Wrapper<'a, Standard>) {
+        let dictionary = Standard::from_embedded(Language::EnglishUS).unwrap();
+        ("with hyphenation", Wrapper::with_splitter(textwrap::termwidth(), dictionary))
     }
 
     let example = "Memory safety without garbage collection. \

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,8 +93,8 @@ pub struct Wrapper<'a, S: WordSplitter> {
     /// `self.width`.
     pub break_words: bool,
     /// The method for splitting words. If the `hyphenation` feature
-    /// is enabled, you can use a `hyphenation::language::Corpus` here
-    /// to get language-aware hyphenation.
+    /// is enabled, you can use a `hyphenation::Standard` dictionary
+    /// here to get language-aware hyphenation.
     pub splitter: S,
 }
 
@@ -706,7 +706,7 @@ mod tests {
 
     use super::*;
     #[cfg(feature = "hyphenation")]
-    use hyphenation::Language;
+    use hyphenation::{Language, Load, Standard};
 
     #[test]
     fn no_wrap() {
@@ -874,14 +874,14 @@ mod tests {
     #[test]
     #[cfg(feature = "hyphenation")]
     fn auto_hyphenation() {
-        let corpus = hyphenation::load(Language::English_US).unwrap();
+        let dictionary = Standard::from_embedded(Language::EnglishUS).unwrap();
         let wrapper = Wrapper::new(10);
         assert_eq!(
             wrapper.wrap("Internationalization"),
             vec!["Internatio", "nalization"]
         );
 
-        let wrapper = Wrapper::with_splitter(10, corpus);
+        let wrapper = Wrapper::with_splitter(10, dictionary);
         assert_eq!(
             wrapper.wrap("Internationalization"),
             vec!["Interna-", "tionaliza-", "tion"]
@@ -893,8 +893,8 @@ mod tests {
     fn split_len_hyphenation() {
         // Test that hyphenation takes the width of the wihtespace
         // into account.
-        let corpus = hyphenation::load(Language::English_US).unwrap();
-        let wrapper = Wrapper::with_splitter(15, corpus);
+        let dictionary = Standard::from_embedded(Language::EnglishUS).unwrap();
+        let wrapper = Wrapper::with_splitter(15, dictionary);
         assert_eq!(
             wrapper.wrap("garbage   collection"),
             vec!["garbage   col-", "lection"]
@@ -907,8 +907,8 @@ mod tests {
         // Lines that end with an extra hyphen are owned, the final
         // line is borrowed.
         use std::borrow::Cow::{Borrowed, Owned};
-        let corpus = hyphenation::load(Language::English_US).unwrap();
-        let wrapper = Wrapper::with_splitter(10, corpus);
+        let dictionary = Standard::from_embedded(Language::EnglishUS).unwrap();
+        let wrapper = Wrapper::with_splitter(10, dictionary);
         let lines = wrapper.wrap("Internationalization");
         if let Borrowed(s) = lines[0] {
             assert!(false, "should not have been borrowed: {:?}", s);
@@ -924,11 +924,11 @@ mod tests {
     #[test]
     #[cfg(feature = "hyphenation")]
     fn auto_hyphenation_with_hyphen() {
-        let corpus = hyphenation::load(Language::English_US).unwrap();
+        let dictionary = Standard::from_embedded(Language::EnglishUS).unwrap();
         let wrapper = Wrapper::new(8).break_words(false);
         assert_eq!(wrapper.wrap("over-caffinated"), vec!["over-", "caffinated"]);
 
-        let wrapper = Wrapper::with_splitter(8, corpus).break_words(false);
+        let wrapper = Wrapper::with_splitter(8, dictionary).break_words(false);
         assert_eq!(
             wrapper.wrap("over-caffinated"),
             vec!["over-", "caffi-", "nated"]

--- a/src/splitting.rs
+++ b/src/splitting.rs
@@ -6,7 +6,7 @@
 //! this treat: it will simply split words on existing hyphens.
 
 #[cfg(feature = "hyphenation")]
-use hyphenation::{Corpus, Hyphenation};
+use hyphenation::{Hyphenator, Standard};
 
 /// An interface for splitting words.
 ///
@@ -119,14 +119,14 @@ impl WordSplitter for HyphenSplitter {
     }
 }
 
-/// A hyphenation Corpus can be used to do language-specific
+/// A hyphenation dictionary can be used to do language-specific
 /// hyphenation using patterns from the hyphenation crate.
 #[cfg(feature = "hyphenation")]
-impl WordSplitter for Corpus {
+impl WordSplitter for Standard {
     fn split<'w>(&self, word: &'w str) -> Vec<(&'w str, &'w str, &'w str)> {
-        // Find splits based on language corpus.
+        // Find splits based on language dictionary.
         let mut triples = Vec::new();
-        for n in word.opportunities(self) {
+        for n in self.hyphenate(word).breaks {
             let (head, tail) = word.split_at(n);
             let hyphen = if head.ends_with('-') { "" } else { "-" };
             triples.push((head, hyphen, tail));


### PR DESCRIPTION
Hyphenation dictionaries are now serialized with stable serde, thus addressing #148.