### PR TITLE
lib: make modules private

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,11 +60,11 @@ use unicode_width::UnicodeWidthStr;
 /// A non-breaking space.
 const NBSP: char = '\u{a0}';
 
-pub mod indentation;
+mod indentation;
 pub use indentation::dedent;
 pub use indentation::indent;
 
-pub mod splitting;
+mod splitting;
 pub use splitting::{HyphenSplitter, NoHyphenation, WordSplitter};
 
 /// A Wrapper holds settings for wrapping and filling text. Use it


### PR DESCRIPTION
The indentation and splitting modules were never intended to be
public. Instead, we re-export the necessary functions and structs at
the top-level of the crate.

The modules are now private again, please use the re-exported names
instead.