### PR TITLE
travis: shorten test time by always building with all features

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
       - checkout
       - run:
           name: Generate coverage report
-          command: cargo tarpaulin --out Xml --features 'term_size hyphenation'
+          command: cargo tarpaulin --out Xml --all-features
       - run:
           name: Upload to codecov.io
           command: bash <(curl -s https://codecov.io/bash) -Z -f cobertura.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,9 @@ rust:
 
 cache: cargo
 
-env:
-  - FEATURES="term_size"
-  - FEATURES="hyphenation"
-
 script:
-  - cargo build --verbose --features "$FEATURES"
-  - cargo test --verbose --features "$FEATURES"
+  - cargo build --verbose --all-features
+  - cargo test --verbose --all-features
 
 matrix:
   allow_failures:


### PR DESCRIPTION
Before we would make do eight test runs for every PR, now we only do
four. Since the features are orthogonal, we can simply test everything
in one go and thus save some time on Travis.