### PR TITLE
emacs: remove dir-locals file

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,3 +1,0 @@
-((nil
-  (bug-reference-bug-regexp . "#\\(?2:[0-9]+\\)")
-  (bug-reference-url-format . "https://github.com/mgeisler/textwrap/issues/%s")))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ readme = "README.md"
 keywords = ["text", "formatting", "wrap", "typesetting", "hyphenation"]
 categories = ["text-processing", "command-line-interface"]
 license = "MIT"
-exclude = [".dir-locals.el"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
I'm not actually using this Emacs feature any longer.