### PR TITLE
travis: bump minimum Rust version to 1.23

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rust:
   - stable
   - beta
   - nightly
-  - 1.22.0
+  - 1.23.0
 
 cache: cargo
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![](https://codecov.io/gh/mgeisler/textwrap/branch/master/graph/badge.svg)][codecov]
 [![](https://img.shields.io/crates/v/textwrap.svg)][crates-io]
 [![](https://docs.rs/textwrap/badge.svg)][api-docs]
-[![](https://img.shields.io/badge/rustc-v1.23.0%2B-4d76ae.svg)][rust-1.23]
+[![](https://img.shields.io/badge/rustc-1.23.0-4d76ae.svg)][rust-1.23]
 
 Textwrap is a small Rust crate for word wrapping text. You can use it
 to format strings for display in commandline applications. The crate

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![](https://codecov.io/gh/mgeisler/textwrap/branch/master/graph/badge.svg)][codecov]
 [![](https://img.shields.io/crates/v/textwrap.svg)][crates-io]
 [![](https://docs.rs/textwrap/badge.svg)][api-docs]
-![](https://img.shields.io/badge/rustc-v1.22.0%2B-4d76ae.svg)
+![](https://img.shields.io/badge/rustc-v1.23.0%2B-4d76ae.svg)
 
 Textwrap is a small Rust crate for word wrapping text. You can use it
 to format strings for display in commandline applications. The crate
@@ -182,6 +182,10 @@ cost abstractions.
 ## Release History
 
 This section lists the largest changes per release.
+
+### Unreleased ###
+
+The the minimum version of Rust we test against is now 1.23.0.
 
 ### Version 0.11.0 — December 9th, 2018
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![](https://codecov.io/gh/mgeisler/textwrap/branch/master/graph/badge.svg)][codecov]
 [![](https://img.shields.io/crates/v/textwrap.svg)][crates-io]
 [![](https://docs.rs/textwrap/badge.svg)][api-docs]
-![](https://img.shields.io/badge/rustc-v1.23.0%2B-4d76ae.svg)
+[![](https://img.shields.io/badge/rustc-v1.23.0%2B-4d76ae.svg)][rust-1.23]
 
 Textwrap is a small Rust crate for word wrapping text. You can use it
 to format strings for display in commandline applications. The crate
@@ -320,6 +320,7 @@ Contributions will be accepted under the same license.
 [py-textwrap]: https://docs.python.org/library/textwrap
 [patterns]: https://github.com/tapeinosyne/hyphenation/tree/master/patterns-tex
 [api-docs]: https://docs.rs/textwrap/
+[rust-1.23]: https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1230-2018-01-04
 [issue-13]: https://github.com/mgeisler/textwrap/issues/13
 [issue-14]: https://github.com/mgeisler/textwrap/issues/14
 [issue-19]: https://github.com/mgeisler/textwrap/issues/19

--- a/tests/version-numbers.rs
+++ b/tests/version-numbers.rs
@@ -41,7 +41,7 @@ fn test_readme_rustc_min_version() {
         .last()
         .expect("No minimum Rust version found");
 
-    let pattern = "https://img.shields.io/badge/rustc-v{version}%2B-4d76ae.svg";
+    let pattern = "https://img.shields.io/badge/rustc-{version}-4d76ae.svg";
     version_sync::check_contains_regex("README.md", pattern, "", min_rust_version)
         .expect("Minimum Rust version not found");
 }


### PR DESCRIPTION
This is due to aho-corasick version 0.7.3 which needs this version.