### PR TITLE
Switch to the Rust 2018 edition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rust:
   - stable
   - beta
   - nightly
-  - 1.23.0
+  - 1.31.0  # Rust 2018
 
 cache: cargo
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ readme = "README.md"
 keywords = ["text", "formatting", "wrap", "typesetting", "hyphenation"]
 categories = ["text-processing", "command-line-interface"]
 license = "MIT"
+edition = "2018"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![](https://codecov.io/gh/mgeisler/textwrap/branch/master/graph/badge.svg)][codecov]
 [![](https://img.shields.io/crates/v/textwrap.svg)][crates-io]
 [![](https://docs.rs/textwrap/badge.svg)][api-docs]
-[![](https://img.shields.io/badge/rustc-1.23.0-4d76ae.svg)][rust-1.23]
+[![](https://img.shields.io/badge/rustc-1.31.0-4d76ae.svg)][rust-1.31]
 
 Textwrap is a small Rust crate for word wrapping text. You can use it
 to format strings for display in commandline applications. The crate
@@ -185,7 +185,8 @@ This section lists the largest changes per release.
 
 ### Unreleased ###
 
-The the minimum version of Rust we test against is now 1.23.0.
+We now require the [Rust 2018 edition][rust-1.31]. This will be a
+stable baseline going forward.
 
 ### Version 0.11.0 — December 9th, 2018
 
@@ -320,7 +321,7 @@ Contributions will be accepted under the same license.
 [py-textwrap]: https://docs.python.org/library/textwrap
 [patterns]: https://github.com/tapeinosyne/hyphenation/tree/master/patterns-tex
 [api-docs]: https://docs.rs/textwrap/
-[rust-1.23]: https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1230-2018-01-04
+[rust-1.31]: https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1310-2018-12-06
 [issue-13]: https://github.com/mgeisler/textwrap/issues/13
 [issue-14]: https://github.com/mgeisler/textwrap/issues/14
 [issue-19]: https://github.com/mgeisler/textwrap/issues/19

--- a/benches/linear.rs
+++ b/benches/linear.rs
@@ -3,13 +3,7 @@
 // The benchmarks here verify that the complexity grows as O(*n*)
 // where *n* is the number of characters in the text to be wrapped.
 
-#[cfg(feature = "hyphenation")]
-extern crate hyphenation;
-extern crate lipsum;
-extern crate rand;
-extern crate rand_xorshift;
 extern crate test;
-extern crate textwrap;
 
 #[cfg(feature = "hyphenation")]
 use hyphenation::{Language, Load, Standard};

--- a/benches/linear.rs
+++ b/benches/linear.rs
@@ -11,8 +11,6 @@ use lipsum::MarkovChain;
 use rand::SeedableRng;
 use rand_xorshift::XorShiftRng;
 use test::Bencher;
-#[cfg(feature = "hyphenation")]
-use textwrap::Wrapper;
 
 const LINE_LENGTH: usize = 60;
 
@@ -84,7 +82,7 @@ fn wrap_800(b: &mut Bencher) {
 fn hyphenation_fill_100(b: &mut Bencher) {
     let text = &lorem_ipsum(100);
     let dictionary = Standard::from_embedded(Language::Latin).unwrap();
-    let wrapper = Wrapper::with_splitter(LINE_LENGTH, dictionary);
+    let wrapper = textwrap::Wrapper::with_splitter(LINE_LENGTH, dictionary);
     b.iter(|| wrapper.fill(text))
 }
 
@@ -93,7 +91,7 @@ fn hyphenation_fill_100(b: &mut Bencher) {
 fn hyphenation_fill_200(b: &mut Bencher) {
     let text = &lorem_ipsum(200);
     let dictionary = Standard::from_embedded(Language::Latin).unwrap();
-    let wrapper = Wrapper::with_splitter(LINE_LENGTH, dictionary);
+    let wrapper = textwrap::Wrapper::with_splitter(LINE_LENGTH, dictionary);
     b.iter(|| wrapper.fill(text))
 }
 
@@ -102,7 +100,7 @@ fn hyphenation_fill_200(b: &mut Bencher) {
 fn hyphenation_fill_400(b: &mut Bencher) {
     let text = &lorem_ipsum(400);
     let dictionary = Standard::from_embedded(Language::Latin).unwrap();
-    let wrapper = Wrapper::with_splitter(LINE_LENGTH, dictionary);
+    let wrapper = textwrap::Wrapper::with_splitter(LINE_LENGTH, dictionary);
     b.iter(|| wrapper.fill(text))
 }
 
@@ -111,6 +109,6 @@ fn hyphenation_fill_400(b: &mut Bencher) {
 fn hyphenation_fill_800(b: &mut Bencher) {
     let text = &lorem_ipsum(800);
     let dictionary = Standard::from_embedded(Language::Latin).unwrap();
-    let wrapper = Wrapper::with_splitter(LINE_LENGTH, dictionary);
+    let wrapper = textwrap::Wrapper::with_splitter(LINE_LENGTH, dictionary);
     b.iter(|| wrapper.fill(text))
 }

--- a/examples/hyphenation.rs
+++ b/examples/hyphenation.rs
@@ -1,8 +1,4 @@
 #[cfg(feature = "hyphenation")]
-extern crate hyphenation;
-extern crate textwrap;
-
-#[cfg(feature = "hyphenation")]
 use hyphenation::{Language, Load, Standard};
 #[cfg(feature = "hyphenation")]
 use textwrap::Wrapper;

--- a/examples/hyphenation.rs
+++ b/examples/hyphenation.rs
@@ -1,7 +1,5 @@
 #[cfg(feature = "hyphenation")]
 use hyphenation::{Language, Load, Standard};
-#[cfg(feature = "hyphenation")]
-use textwrap::Wrapper;
 
 #[cfg(not(feature = "hyphenation"))]
 fn main() {
@@ -14,6 +12,6 @@ fn main() {
 fn main() {
     let text = "textwrap: a small library for wrapping text.";
     let dictionary = Standard::from_embedded(Language::EnglishUS).unwrap();
-    let wrapper = Wrapper::with_splitter(18, dictionary);
+    let wrapper = textwrap::Wrapper::with_splitter(18, dictionary);
     println!("{}", wrapper.fill(text));
 }

--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -1,8 +1,4 @@
 #[cfg(feature = "hyphenation")]
-extern crate hyphenation;
-extern crate textwrap;
-
-#[cfg(feature = "hyphenation")]
 use hyphenation::{Language, Load};
 use textwrap::Wrapper;
 

--- a/examples/termwidth.rs
+++ b/examples/termwidth.rs
@@ -1,8 +1,4 @@
 #[cfg(feature = "hyphenation")]
-extern crate hyphenation;
-extern crate textwrap;
-
-#[cfg(feature = "hyphenation")]
 use hyphenation::{Language, Load, Standard};
 #[cfg(feature = "term_size")]
 use textwrap::Wrapper;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,12 +76,6 @@
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
 
-#[cfg(feature = "hyphenation")]
-extern crate hyphenation;
-#[cfg(feature = "term_size")]
-extern crate term_size;
-extern crate unicode_width;
-
 use std::borrow::Cow;
 use std::str::CharIndices;
 
@@ -92,11 +86,11 @@ use unicode_width::UnicodeWidthStr;
 const NBSP: char = '\u{a0}';
 
 mod indentation;
-pub use indentation::dedent;
-pub use indentation::indent;
+pub use crate::indentation::dedent;
+pub use crate::indentation::indent;
 
 mod splitting;
-pub use splitting::{HyphenSplitter, NoHyphenation, WordSplitter};
+pub use crate::splitting::{HyphenSplitter, NoHyphenation, WordSplitter};
 
 /// A Wrapper holds settings for wrapping and filling text. Use it
 /// when the convenience [`wrap_iter`], [`wrap`] and [`fill`] functions
@@ -433,7 +427,7 @@ impl<'a, S: WordSplitter> Iterator for IntoWrapIter<'a, S> {
 ///
 /// [`Wrapper::wrap_iter`]: struct.Wrapper.html#method.wrap_iter
 #[derive(Debug)]
-pub struct WrapIter<'w, 'a: 'w, S: WordSplitter + 'w> {
+pub struct WrapIter<'w, 'a: 'w, S: WordSplitter> {
     wrapper: &'w Wrapper<'a, S>,
     inner: WrapIterImpl<'a>,
 }
@@ -682,7 +676,7 @@ pub fn fill(s: &str, width: usize) -> String {
 ///
 /// [`wrap_iter`]: fn.wrap_iter.html
 /// [`wrap` method]: struct.Wrapper.html#method.wrap
-pub fn wrap(s: &str, width: usize) -> Vec<Cow<str>> {
+pub fn wrap(s: &str, width: usize) -> Vec<Cow<'_, str>> {
     Wrapper::new(width).wrap(s)
 }
 
@@ -717,7 +711,7 @@ pub fn wrap(s: &str, width: usize) -> Vec<Cow<str>> {
 /// [`into_wrap_iter`]: struct.Wrapper.html#method.into_wrap_iter
 /// [`IntoWrapIter`]: struct.IntoWrapIter.html
 /// [`WrapIter`]: struct.WrapIter.html
-pub fn wrap_iter(s: &str, width: usize) -> IntoWrapIter<HyphenSplitter> {
+pub fn wrap_iter(s: &str, width: usize) -> IntoWrapIter<'_, HyphenSplitter> {
     Wrapper::new(width).into_wrap_iter(s)
 }
 

--- a/tests/version-numbers.rs
+++ b/tests/version-numbers.rs
@@ -1,19 +1,15 @@
-#[macro_use]
-extern crate version_sync;
-extern crate yaml_rust;
-
 use std::fs::File;
 use std::io::Read;
 use yaml_rust::YamlLoader;
 
 #[test]
 fn test_readme_deps() {
-    assert_markdown_deps_updated!("README.md");
+    version_sync::assert_markdown_deps_updated!("README.md");
 }
 
 #[test]
 fn test_readme_changelog() {
-    assert_contains_regex!(
+    version_sync::assert_contains_regex!(
         "README.md",
         r"^### Version {version} — .* \d\d?.., 20\d\d$"
     );
@@ -48,5 +44,5 @@ fn test_readme_rustc_min_version() {
 
 #[test]
 fn test_html_root_url() {
-    assert_html_root_url_updated!("src/lib.rs");
+    version_sync::assert_html_root_url_updated!("src/lib.rs");
 }


### PR DESCRIPTION
This allows us to remove almost all `extern crate` statements.