### PR TITLE
Run cargo tarpaulin in a machine image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,18 @@
 version: 2
 jobs:
   build:
-    docker:
-      - image: xd009642/tarpaulin
+    machine: true
     steps:
       - checkout
       - run:
+          name: Pull xd009642/tarpaulin
+          command: docker pull xd009642/tarpaulin
+      - run:
           name: Generate coverage report
-          command: cargo tarpaulin --out Xml --all-features
+          command: >-
+            docker run --security-opt seccomp=unconfined
+            -v $PWD:/volume xd009642/tarpaulin
+            cargo tarpaulin --out Xml --all-features
       - run:
           name: Upload to codecov.io
           command: bash <(curl -s https://codecov.io/bash) -Z -f cobertura.xml


### PR DESCRIPTION
This way we can specify the necessary Docker security options to let
Tarpaulin run while still getting the benefits of using a prebuilt
Docker image.