### PR TITLE
cargo: fix rand_xorshift version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,4 @@ cache: cargo
 script:
   - cargo build --verbose --all-features
   - cargo test --verbose --all-features
-
-matrix:
-  allow_failures:
-    - rust: nightly
+  - if [[ $TRAVIS_RUST_VERSION == "nightly" ]]; then cargo build --benches; fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,6 @@ hyphenation = { version = "0.7.1", optional = true, features = ["embed_all"] }
 [dev-dependencies]
 lipsum = "0.6"
 rand = "0.6"
-rand_xorshift = "0.2"
+rand_xorshift = "0.1"
 version-sync = "0.8"
 yaml-rust = "0.4"


### PR DESCRIPTION
Version 0.2 seems to only work with rand 0.8, but we're using rand 0.6
in order to stay compatible with Rust 2018.