### PR TITLE
travis: drop beta Rust target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: rust
 
 rust:
   - stable
-  - beta
   - nightly
   - 1.31.0  # Rust 2018
 


### PR DESCRIPTION
I don't think we've ever seen a build failure on this target so it
seems like a waste to continuously build it.