### PR TITLE
cargo: bump term_size to latest version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ codecov = { repository = "mgeisler/textwrap" }
 
 [dependencies]
 unicode-width = "0.1.3"
-term_size = { version = "0.3.0", optional = true }
+term_size = { version = "1.0.0-beta1", optional = true }
 hyphenation = { version = "0.7.1", optional = true, features = ["embed_all"] }
 
 [dev-dependencies]


### PR DESCRIPTION
This is a beta version, so we'll relax the dependency to 1.0 when the
actual release is made.

Fixes #172.