### PR TITLE
termsize: switch from term_size to terminal_size

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,11 @@ rust:
   - nightly
 
 install:
-  - cargo build --all-features
+  - cargo build --all-features --tests --examples
+  - >
+    if [[ $TRAVIS_RUST_VERSION == "nightly" ]]; then
+        cargo build --all-features --benches
+    fi
 
 script:
   - cargo test --all-features
-  - if [[ $TRAVIS_RUST_VERSION == "nightly" ]]; then cargo build --benches; fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ codecov = { repository = "mgeisler/textwrap" }
 
 [dependencies]
 unicode-width = "0.1.3"
-term_size = { version = "1.0.0-beta1", optional = true }
+terminal_size = { version = "0.1.11", optional = true }
 hyphenation = { version = "0.7.1", optional = true, features = ["embed_all"] }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ textwrap = { version = "0.11", features = ["hyphenation"] }
 ```
 
 To conveniently wrap text at the current terminal width, enable the
-`term_size` feature:
+`terminal_size` feature:
 
 ```toml
 [dependencies]
-textwrap = { version = "0.11", features = ["term_size"] }
+textwrap = { version = "0.11", features = ["terminal_size"] }
 ```
 
 ## Documentation
@@ -194,6 +194,8 @@ The build failures makes it infeasible to keep `textwrap` compatible
 with any particular version of Rust. We will therefore track the
 latest stable version of Rust from now on.
 
+The `term_size` feature has been replaced by `terminal_size`. The API
+is unchanged, it is just the name of the Cargo feature that changed.
 
 ### Version 0.11.0 — December 9th, 2018
 

--- a/examples/termwidth.rs
+++ b/examples/termwidth.rs
@@ -1,14 +1,14 @@
 #[cfg(feature = "hyphenation")]
 use hyphenation::{Language, Load, Standard};
-#[cfg(feature = "term_size")]
+#[cfg(feature = "terminal_size")]
 use textwrap::Wrapper;
 
-#[cfg(not(feature = "term_size"))]
+#[cfg(not(feature = "terminal_size"))]
 fn main() {
-    println!("Please enable the term_size feature to run this example.");
+    println!("Please enable the terminal_size feature to run this example.");
 }
 
-#[cfg(feature = "term_size")]
+#[cfg(feature = "terminal_size")]
 fn main() {
     #[cfg(not(feature = "hyphenation"))]
     fn new_wrapper<'a>() -> (&'static str, Wrapper<'a, textwrap::HyphenSplitter>) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,7 +149,7 @@ impl<'a> Wrapper<'a, HyphenSplitter> {
     ///
     /// let wrapper = Wrapper::new(termwidth());
     /// ```
-    #[cfg(feature = "term_size")]
+    #[cfg(feature = "terminal_size")]
     pub fn with_termwidth() -> Wrapper<'a, HyphenSplitter> {
         Wrapper::new(termwidth())
     }
@@ -619,9 +619,9 @@ impl<'a> WrapIterImpl<'a> {
 ///     .initial_indent("  ")
 ///     .subsequent_indent("  ");
 /// ```
-#[cfg(feature = "term_size")]
+#[cfg(feature = "terminal_size")]
 pub fn termwidth() -> usize {
-    term_size::dimensions_stdout().map_or(80, |(w, _)| w)
+    terminal_size::terminal_size().map_or(80, |(terminal_size::Width(w), _)| w.into())
 }
 
 /// Fill a line of text at `width` characters.


### PR DESCRIPTION
The `term_size` crate seems unmaintained, as mentioned in #179.