### PR TITLE
Improve documentation of Cargo features

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,23 @@ To use `textwrap`, add this to your `Cargo.toml` file:
 textwrap = "0.11"
 ```
 
-If you would like to have automatic hyphenation, specify the
-dependency as:
+This gives you the text wrapping without of the optional features
+listed next.
+
+### `hyphenation`
+
+If you would like to have automatic language-sensitive hyphenation,
+enable the `hyphenation` feature:
+
 ```toml
 [dependencies]
 textwrap = { version = "0.11", features = ["hyphenation"] }
 ```
+
+Please see the [`hyphenation` example][hyphenation-example] for how to
+load the hyphenation patterns for your language.
+
+### `terminal_size`
 
 To conveniently wrap text at the current terminal width, enable the
 `terminal_size` feature:
@@ -33,6 +44,9 @@ To conveniently wrap text at the current terminal width, enable the
 [dependencies]
 textwrap = { version = "0.11", features = ["terminal_size"] }
 ```
+
+Please see the [`termwidth` example][termwidth-example] for how to use
+this feature.
 
 ## Documentation
 
@@ -319,6 +333,8 @@ Contributions will be accepted under the same license.
 [appveyor]: https://ci.appveyor.com/project/mgeisler/textwrap
 [codecov]: https://codecov.io/gh/mgeisler/textwrap
 [py-textwrap]: https://docs.python.org/library/textwrap
+[hyphenation-example]: https://github.com/mgeisler/textwrap/blob/master/examples/hyphenation.rs
+[termwidth-example]: https://github.com/mgeisler/textwrap/blob/master/examples/termwidth.rs
 [patterns]: https://github.com/tapeinosyne/hyphenation/tree/master/patterns-tex
 [api-docs]: https://docs.rs/textwrap/
 [rust-2018]: https://doc.rust-lang.org/edition-guide/rust-2018/

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,23 @@
 //! byte count when computing line lengths. All functions in this
 //! library handle Unicode characters like this.
 //!
+//! # Cargo Features
+//!
+//! The library has two optional features:
+//!
+//! * `terminal_size`: enables automatic detection of the terminal
+//!   width via the [terminal_size][] crate. See the
+//!   [`Wrapper::with_termwidth`] constructor for details.
+//!
+//! * `hyphenation`: enables language-sentive hyphenation via the
+//!   [hyphenation][] crate. See the [`WordSplitter`] trait for
+//!   details.
+//!
 //! [unicode-width]: https://docs.rs/unicode-width/
+//! [terminal_size]: https://crates.io/crates/terminal_size
+//! [hyphenation]: https://crates.io/crates/hyphenation
+//! [`Wrapper::with_termwidth`]: struct.Wrapper.html#method.with_termwidth
+//! [`WordSplitter`]: trait.WordSplitter.html
 
 #![doc(html_root_url = "https://docs.rs/textwrap/0.11.0")]
 #![deny(missing_docs)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,6 +150,9 @@ impl<'a> Wrapper<'a, HyphenSplitter> {
     ///
     /// let wrapper = Wrapper::new(termwidth());
     /// ```
+    ///
+    /// **Note:** Only available when the `terminal_size` feature is
+    /// enabled.
     #[cfg(feature = "terminal_size")]
     pub fn with_termwidth() -> Wrapper<'a, HyphenSplitter> {
         Wrapper::new(termwidth())
@@ -634,6 +637,9 @@ impl<'a> WrapIterImpl<'a> {
 ///     .initial_indent("  ")
 ///     .subsequent_indent("  ");
 /// ```
+///
+/// **Note:** Only available when the `terminal_size` feature is
+/// enabled.
 #[cfg(feature = "terminal_size")]
 pub fn termwidth() -> usize {
     terminal_size::terminal_size().map_or(80, |(terminal_size::Width(w), _)| w.into())

--- a/src/splitting.rs
+++ b/src/splitting.rs
@@ -121,6 +121,9 @@ impl WordSplitter for HyphenSplitter {
 
 /// A hyphenation dictionary can be used to do language-specific
 /// hyphenation using patterns from the hyphenation crate.
+///
+/// **Note:** Only available when the `hyphenation` feature is
+/// enabled.
 #[cfg(feature = "hyphenation")]
 impl WordSplitter for Standard {
     fn split<'w>(&self, word: &'w str) -> Vec<(&'w str, &'w str, &'w str)> {


### PR DESCRIPTION
This makes it explicit when a Cargo feature is needed to enable a function.

Fixes #165.
