### PR TITLE
Update hyphenation to v0.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ codecov = { repository = "mgeisler/textwrap" }
 [dependencies]
 unicode-width = "0.1.3"
 terminal_size = { version = "0.1.11", optional = true }
-hyphenation = { version = "0.7.1", optional = true, features = ["embed_all"] }
+hyphenation = { version = "0.8.0", optional = true, features = ["embed_all"] }
 
 [dev-dependencies]
 lipsum = "0.6"

--- a/src/splitting.rs
+++ b/src/splitting.rs
@@ -18,7 +18,7 @@ use hyphenation::{Hyphenator, Standard};
 ///
 /// If the `textwrap` crate has been compiled with the `hyphenation`
 /// feature enabled, you will find an implementation of `WordSplitter`
-/// by the `hyphenation::language::Corpus` struct. Use this struct for
+/// by the `hyphenation::Standard` struct. Use this struct for
 /// language-aware hyphenation. See the [`hyphenation` documentation]
 /// for details.
 ///


### PR DESCRIPTION
The new release addresses https://github.com/tapeinosyne/hyphenation/issues/24, which caused spurious rebuilds in `textwrap` if the `hyphenation` feature was enabled.

Relevantly for `textwrap`, it also decreases the size of embedded dictionaries from over 8MB to about 2.8MB, and introduces the `embed_en-us` feature to only bundle the dictionary for American English, which might suffice for CLIs.