### PR TITLE
clippy: fix/silence Clippy warnings

### DIFF
--- a/src/indentation.rs
+++ b/src/indentation.rs
@@ -150,7 +150,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     fn indent_nonempty() {
         let x = vec!["  foo",
                      "bar",
@@ -162,7 +162,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     fn indent_empty_line() {
         let x = vec!["  foo",
                      "bar",
@@ -181,7 +181,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     fn dedent_multi_line() {
         let x = vec!["    foo",
                      "  bar",
@@ -193,7 +193,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     fn dedent_empty_line() {
         let x = vec!["    foo",
                      "  bar",
@@ -207,7 +207,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     fn dedent_blank_line() {
         let x = vec!["      foo",
                      "",
@@ -225,7 +225,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     fn dedent_whitespace_line() {
         let x = vec!["      foo",
                      " ",
@@ -243,7 +243,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     fn dedent_mixed_whitespace() {
         let x = vec!["\tfoo",
                      "  bar"];
@@ -253,7 +253,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     fn dedent_tabbed_whitespace() {
         let x = vec!["\t\tfoo",
                      "\t\t\tbar"];
@@ -263,7 +263,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     fn dedent_mixed_tabbed_whitespace() {
         let x = vec!["\t  \tfoo",
                      "\t  \t\tbar"];
@@ -273,7 +273,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     fn dedent_mixed_tabbed_whitespace2() {
         let x = vec!["\t  \tfoo",
                      "\t    \tbar"];
@@ -283,7 +283,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     fn dedent_preserve_no_terminating_newline() {
         let x = vec!["  foo",
                      "    bar"].join("\n");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,7 @@
 #![doc(html_root_url = "https://docs.rs/textwrap/0.12.0")]
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
+#![allow(clippy::redundant_field_names)]
 
 use std::borrow::Cow;
 use std::str::CharIndices;


### PR DESCRIPTION
I silenced the clippy::redundant_field_names lint since I prefer to be
consistent and always use the field names when creating structs.