### PR TITLE
Link to the textwrap-macros crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 This file lists the most important changes made in each release of
 `textwrap`.
 
+## Unreleased
+
+* Fixed [#176][issue-176]: Compile-time wrapping via the
+  [`textwrap-macros` crate].
+
 ## Version 0.12.0 — June 26th, 2020
 
 The code has been updated to the [Rust 2018 edition][rust-2018] and
@@ -143,6 +148,8 @@ Introduced `Wrapper` struct. Added support for wrapping on hyphens.
 First public release with support for wrapping strings on whitespace.
 
 [rust-2018]: https://doc.rust-lang.org/edition-guide/rust-2018/
+[`textwrap-macros` crate]: https://crates.io/crates/textwrap-macros
+
 [issue-13]: https://github.com/mgeisler/textwrap/issues/13
 [issue-14]: https://github.com/mgeisler/textwrap/issues/14
 [issue-19]: https://github.com/mgeisler/textwrap/issues/19

--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ application. If you need hyphenation for other languages, you need to
 download a [precompiled `.bincode` file][bincode] and load it
 yourself. Please see the [`hyphenation` documentation] for details.
 
+## Wrapping Strings at Compile Time
+
+If your strings are known at compile time, please take a look at the
+procedural macros from the [`textwrap-macros` crate].
+
+
 ## Examples
 
 The library comes with some small example programs that shows various
@@ -206,6 +212,7 @@ Contributions will be accepted under the same license.
 [appveyor]: https://ci.appveyor.com/project/mgeisler/textwrap
 [codecov]: https://codecov.io/gh/mgeisler/textwrap
 [py-textwrap]: https://docs.python.org/library/textwrap
+[`textwrap-macros` crate]: https://crates.io/crates/textwrap-macros
 [`hyphenation` example]: https://github.com/mgeisler/textwrap/blob/master/examples/hyphenation.rs
 [`termwidth` example]: https://github.com/mgeisler/textwrap/blob/master/examples/termwidth.rs
 [patterns]: https://github.com/tapeinosyne/hyphenation/tree/master/patterns-tex

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,11 @@
 //! ping text.
 //! ```
 //!
+//! # Wrapping Strings at Compile Time
+//!
+//! If your strings are known at compile time, please take a look at
+//! the procedural macros from the [`textwrap-macros` crate].
+//!
 //! # Displayed Width vs Byte Size
 //!
 //! To word wrap text, one must know the width of each word so one can
@@ -76,6 +81,7 @@
 //!   [hyphenation][] crate. See the [`WordSplitter`] trait for
 //!   details.
 //!
+//! [`textwrap-macros` crate]: https://crates.io/crates/textwrap-macros
 //! [unicode-width]: https://docs.rs/unicode-width/
 //! [terminal_size]: https://crates.io/crates/terminal_size
 //! [hyphenation]: https://crates.io/crates/hyphenation


### PR DESCRIPTION
The crate makes it possible to use textwrap at compile time.

Fixes #176