### PR TITLE
Use larger benchmark sizes to improve benchmark stability

### DIFF
--- a/benches/linear.rs
+++ b/benches/linear.rs
@@ -21,7 +21,7 @@ fn lorem_ipsum(length: usize) -> String {
 
 pub fn benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("String lengths");
-    for length in [100, 160, 220, 280, 340, 400].iter() {
+    for length in [100, 200, 400, 800, 1600].iter() {
         let text = lorem_ipsum(*length);
         group.bench_with_input(BenchmarkId::new("fill", length), &text, |b, text| {
             b.iter(|| textwrap::fill(text, LINE_LENGTH));


### PR DESCRIPTION
Even with 1600 character long strings (roughly 20 lines of text in a terminal), the timings for the three benchmarks are tiny:

    fill/1600:         9.885 us
    wrap/1600:        10.277 us
    hyphenation/1600: 40.196 us