### PR TITLE
Reintroducing the type parameter on `Options` (previously known as `Wrapper`).

### DIFF
--- a/benches/linear.rs
+++ b/benches/linear.rs
@@ -23,8 +23,13 @@ pub fn benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("String lengths");
     for length in [100, 200, 400, 800, 1600].iter() {
         let text = lorem_ipsum(*length);
-        let mut options = textwrap::Options::new(LINE_LENGTH);
+        let options = textwrap::Options::new(LINE_LENGTH);
         group.bench_with_input(BenchmarkId::new("fill", length), &text, |b, text| {
+            b.iter(|| textwrap::fill(text, &options));
+        });
+
+        let options: textwrap::Options = options.splitter(Box::new(textwrap::HyphenSplitter));
+        group.bench_with_input(BenchmarkId::new("fill_boxed", length), &text, |b, text| {
             b.iter(|| textwrap::fill(text, &options));
         });
 
@@ -39,11 +44,11 @@ pub fn benchmark(c: &mut Criterion) {
                 .join("benches")
                 .join("la.standard.bincode");
             let dictionary = Standard::from_path(Language::Latin, &path).unwrap();
-            options.splitter = Box::new(dictionary);
+            let options = options.splitter(dictionary);
             group.bench_with_input(BenchmarkId::new("hyphenation", length), &text, |b, text| {
                 b.iter(|| textwrap::fill(text, &options));
             });
-        }
+        };
     }
     group.finish();
 }

--- a/examples/hyphenation.rs
+++ b/examples/hyphenation.rs
@@ -12,6 +12,6 @@ fn main() {
 fn main() {
     let text = "textwrap: a small library for wrapping text.";
     let dictionary = Standard::from_embedded(Language::EnglishUS).unwrap();
-    let options = textwrap::Options::new(18).splitter(Box::new(dictionary));
+    let options = textwrap::Options::new(18).splitter(dictionary);
     println!("{}", textwrap::fill(text, &options));
 }

--- a/examples/interactive.rs
+++ b/examples/interactive.rs
@@ -164,7 +164,7 @@ mod unix_only {
         }
 
         let mut label = labels.pop().unwrap();
-        let mut options = Options::new(initial_width);
+        let mut options: Options = Options::new(initial_width).splitter(Box::new(HyphenSplitter));
         options.break_words = false;
         options.splitter = splitters.pop().unwrap();
 
@@ -203,7 +203,7 @@ mod unix_only {
 
         // TODO: change to cursor::DefaultStyle if
         // https://github.com/redox-os/termion/pull/157 is merged.
-        screen.write(b"\x1b[0 q")?;
+        screen.write_all(b"\x1b[0 q")?;
         screen.flush()
     }
 }

--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -1,4 +1,4 @@
-use textwrap::{wrap, Options};
+use textwrap::{wrap, HyphenSplitter, Options};
 
 fn main() {
     let example = "Memory safety without garbage collection. \
@@ -6,7 +6,7 @@ fn main() {
                    Zero-cost abstractions.";
     let mut prev_lines = vec![];
 
-    let mut options = Options::new(0);
+    let mut options: Options = Options::new(0).splitter(Box::new(HyphenSplitter));
     #[cfg(feature = "hyphenation")]
     {
         use hyphenation::Load;

--- a/examples/termwidth.rs
+++ b/examples/termwidth.rs
@@ -21,9 +21,9 @@ fn main() {
     #[cfg(feature = "hyphenation")]
     let (msg, options) = (
         "with hyphenation",
-        Options::with_termwidth().splitter(Box::new(
+        Options::with_termwidth().splitter(
             hyphenation::Standard::from_embedded(hyphenation::Language::EnglishUS).unwrap(),
-        )),
+        ),
     );
 
     println!("Formatted {} in {} columns:", msg, options.width);

--- a/src/core.rs
+++ b/src/core.rs
@@ -236,7 +236,7 @@ pub fn find_words(line: &str) -> impl Iterator<Item = Word> {
 /// );
 ///
 /// // The NoHyphenation splitter ignores the '-':
-/// let options = Options::new(80).splitter(Box::new(NoHyphenation));
+/// let options = Options::new(80).splitter(NoHyphenation);
 /// assert_eq!(
 ///     split_words(vec![Word::from("foo-bar")], &&options).collect::<Vec<_>>(),
 ///     vec![Word::from("foo-bar")]
@@ -548,7 +548,7 @@ mod tests {
             }
         }
 
-        let options = Options::new(80).splitter(Box::new(FixedSplitPoint));
+        let options = Options::new(80).splitter(FixedSplitPoint);
         assert_iter_eq!(
             split_words(vec![Word::from("foobar")].into_iter(), &&options),
             vec![

--- a/src/splitting.rs
+++ b/src/splitting.rs
@@ -54,7 +54,7 @@ impl<S: WordSplitter + ?Sized> WordSplitter for Box<S> {
 /// ```
 /// use textwrap::{wrap, Options, NoHyphenation};
 ///
-/// let options = Options::new(8).splitter(Box::new(NoHyphenation));
+/// let options = Options::new(8).splitter(NoHyphenation);
 /// assert_eq!(wrap("foo bar-baz", &options),
 ///            vec!["foo", "bar-baz"]);
 /// ```

--- a/src/splitting.rs
+++ b/src/splitting.rs
@@ -33,6 +33,21 @@ pub trait WordSplitter: std::fmt::Debug {
     fn split_points(&self, word: &str) -> Vec<usize>;
 }
 
+impl WordSplitter for Box<dyn WordSplitter> {
+    fn split_points(&self, word: &str) -> Vec<usize> {
+        use std::ops::Deref;
+        self.deref().split_points(word)
+    }
+}
+/* Alternative, also adds impls for specific Box<S> i.e. Box<HyphenSplitter>
+impl<S: WordSplitter + ?Sized> WordSplitter for Box<S> {
+    fn split<'w>(&self, word: &'w str) -> Vec<(&'w str, &'w str, &'w str)> {
+        use std::ops::Deref;
+        self.deref().split(word)
+    }
+}
+*/
+
 /// Use this as a [`Options.splitter`] to avoid any kind of
 /// hyphenation:
 ///


### PR DESCRIPTION
This PR reverts the internal changes of #206, but keeps the public API compatible to what it introduced. Essentially by adding a default for the type parameter.

However, now in addition to the dynamic dispatch by default, one may also explicitly use static dispatch by specifying a concrete type parameter. This now allows to construct an `Options` instance in const/static context (or introduces, it depending on the point of view, as it was possible before #206). Which is further facilitated by adding the const fns `new_const` and `with_splitter`.

### Open Questions

* The name of `Options::new_const` could be changed (maybe to `new_static`). Or, for instance, the `Options::new_const` could replace the current `Options::new` entirely, reverting to a static dispatch by default. Then instead, a `Options::new_boxed` (or `new_dyn` or something) could be added which then creates a boxed `Options` with dynamic dispatch. Yet another alternative, would be to just remove `Options::new_const`, since the fundamental use-case (const fn) is also covered by `Options::with_splitter`.
* Whether to implement `WordSplitter` only for `Box<dyn WordSplitter>` or for all `Box<S>`
* Whether to implement `splitter` setter method only on the dynamic dispatch variant (aka `Options<Box<dyn WordSplitter>>`). Then, it might also take an arbitrary `impl WordSplitter` by value and put it into a `Box`.
* Now, it is also possible to make `Options` `Clone` again. Well, at least where the type parameter is `Clone`, which it isn't for the default `Box<dyn WordSplitter>`.

_comments & other suggestions are welcome_