### PR TITLE
Forbid the use of unsafe code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,7 @@
 //! [`WordSplitter`]: trait.WordSplitter.html
 
 #![doc(html_root_url = "https://docs.rs/textwrap/0.12.1")]
+#![forbid(unsafe_code)] // See https://github.com/mgeisler/textwrap/issues/210
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
 #![allow(clippy::redundant_field_names)]


### PR DESCRIPTION
We currently don't have any unsafe code in `textwrap` -- adding this attribute ensure that we'll think careful about it before adding any. The [Rust Safety Dance project](https://github.com/rust-secure-code/safety-dance/) promises to be a great resource in ensuring that any unsafe code added is, infact, safe.

Fixes #210.