### PR TITLE
Blanket impl for types that deref to WordSplitter

### DIFF
--- a/src/splitting.rs
+++ b/src/splitting.rs
@@ -56,6 +56,16 @@ pub trait WordSplitter: std::fmt::Debug {
 #[derive(Clone, Debug)]
 pub struct NoHyphenation;
 
+impl<T> WordSplitter for T
+where
+    T: std::ops::Deref + std::fmt::Debug,
+    T::Target: WordSplitter,
+{
+    fn split<'w>(&self, word: &'w str) -> Vec<(&'w str, &'w str, &'w str)> {
+        (**self).split(word)
+    }
+}
+
 /// `NoHyphenation` implements `WordSplitter` by not splitting the
 /// word at all.
 impl WordSplitter for NoHyphenation {


### PR DESCRIPTION
I ran into a situation where it would be useful to use `&hyphenation::Standard` as a splitter. This PR adds a blanket `WordSplitter` impl for anything that derefs to a `WordSplitter`, which should cover cases like this.