### PR TITLE
Allow using trait objects with `fill` & `wrap`.

### DIFF
--- a/examples/multi-layouts.rs
+++ b/examples/multi-layouts.rs
@@ -1,0 +1,99 @@
+use textwrap::{NoHyphenation, Options};
+
+#[cfg(feature = "hyphenation")]
+use hyphenation::{Language, Load, Standard};
+
+// Pretend this is an external crate
+mod library {
+    use textwrap::{Options, WordSplitter};
+
+    #[derive(Debug, Default)]
+    pub struct Layout<'a> {
+        // Use trait-objects which can be easily converted from any concrete `Options`
+        styles: Vec<Box<Options<'a, dyn WordSplitter + 'a>>>,
+    }
+
+    impl<'a> Layout<'a> {
+        pub fn new() -> Self {
+            Default::default()
+        }
+
+        // Similar signature like `wrap` has, so it takes (nearly) everything that `warp` takes.
+        pub fn add<S: WordSplitter + 'a, T: Into<Options<'a, S>>>(&mut self, option: T) {
+            self.styles.push(Box::new(option.into()));
+        }
+
+        pub fn print(&self, text: &str) {
+            // Now we can easily go over all the arbitrary Options and use them for layouting.
+            for opt in self.styles.iter() {
+                println!();
+
+                // the debug output of the hyphenation is very long
+                //println!("Options: {:#?}", opt);
+
+                println!("{:0width$}", 0, width = opt.width);
+
+                // Just use the textwrap functions as usual.
+                // However, we have to first coerce it into a trait-object
+                let dyn_opt: &Options<'a, dyn WordSplitter> = opt;
+                println!("{}", textwrap::fill(text, dyn_opt));
+            }
+        }
+    }
+}
+
+pub fn main() {
+    // pretend we are a user of the library module above
+
+    // Just some options (see below for usage)
+    let some_opt = Options::new(25).initial_indent("----");
+
+    // The struct from the 'library' that we are using
+    let mut layout = library::Layout::new();
+
+    // Add some arbitrary options. We can use here the same as for `fill` & `wrap`.
+
+    // Plain Options
+    layout.add(Options::new(20));
+
+    // usize
+    layout.add(30);
+
+    // Customized Options
+    let opt = Options::new(30);
+    let opt = opt.subsequent_indent("****");
+    layout.add(opt.clone()); // notice, here we pass opt by-value instead of by-reference
+
+    // We can use boxed splitters too (however, we have to coerce the Options)
+    let opt: Options = opt.splitter(Box::new(NoHyphenation));
+    layout.add(opt);
+
+    // We can also pass-in references, however, those need to outlive the local
+    // `layout`, so here, it must be declared before `layout` (drop order).
+    layout.add(&some_opt);
+
+    // If you like, you can download more dictionaries from
+    // https://github.com/tapeinosyne/hyphenation/tree/master/dictionaries
+    // Place the dictionaries in the examples/ directory. Here we
+    // just load the embedded en-us dictionary.
+    #[cfg(feature = "hyphenation")]
+    for lang in &[Language::EnglishUS] {
+        let dictionary = Standard::from_embedded(*lang).or_else(|_| {
+            let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("examples")
+                .join(format!("{}.standard.bincode", lang.code()));
+            Standard::from_path(*lang, &path)
+        });
+
+        if let Ok(dict) = dictionary {
+            layout.add(Options::with_splitter(25, dict));
+        }
+    }
+
+    let example = "Memory safety without garbage collection. \
+                   Concurrency without data races. \
+                   Zero-cost abstractions.";
+
+    // Printout above text in all different layouts
+    layout.print(example);
+}

--- a/src/splitting.rs
+++ b/src/splitting.rs
@@ -47,7 +47,7 @@ impl<S: WordSplitter + ?Sized> WordSplitter for Box<S> {
     }
 }
 */
-impl<T: WordSplitter> WordSplitter for &T {
+impl<T: ?Sized + WordSplitter> WordSplitter for &T {
     fn split_points(&self, word: &str) -> Vec<usize> {
         (*self).split_points(word)
     }


### PR DESCRIPTION
Considering the issue #178 with the current state of `master`, using trait objects with `fill` & `wrap` seems to be a straight forward solution. However, until now, it is not supported by these functions. One problem is that they take the `WrapOptions` by-value, which is incompatible with trait objects.

Digging a bit deeper, it seems that the `WrapIter` already uses the `WrapOptions` by-value, but that trait only defines function that require access via reference. Additionally, considering that the `WrapIter` is typically a rather short-lived entity, it does seem justified to give it owned access to something it only borrows. This issue is also reflected by the implementation for `Options`, which as of now, implements `WrapOptions` only on a reference (i.e. `&Options`).

This PR rectifies this inconsistency by giving `WrapIter` only a reference to some `WrapOptions`. Now, it is no longer required that the given type is sized, and it directly allows for trait objects to be used.

However, the current implementation of this PR, has the drawback that the `usize` as `WrapOptions` must also be given by-reference so a simple `fill("text", 42)` becomes `fill("text", &42)`, it shouldn't cause any issues, but the additional ampersand (`&`) isn't the prettiest.

As shown by a newly added test the following idiom using trait objects becomes now possible due to this PR:

```rust
// Storing the WrapOptions as a boxed trait object. (notice, also `Rc`, `Arc`, and others are possible)
let mut wrapper: Box<dyn WrapOptions> = Box::new(Options::new(80));

assert_iter_eq!(wrap("foo bar baz", &*wrapper), vec!["foo bar baz"]);

// Replace the `Options` with a `usize`
wrapper = Box::new(5);

assert_iter_eq!(wrap("foo bar baz", &*wrapper), vec!["foo", "bar", "baz"]);
```

_This is a follow-up to my early comment, it implements what I called 'proper outer boxing' https://github.com/mgeisler/textwrap/pull/215#issuecomment-722058439_