### PR TITLE
Fix reference to nonexisting fill_with function

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ fn main() {
     let hyphenator = Standard::from_embedded(Language::EnglishUS).unwrap();
     let options = Options::new(18).splitter(Box::new(hyphenator));
     let text = "textwrap: a small library for wrapping text.";
-    println!("{}", fill_with(text, &options);
+    println!("{}", fill(text, &options);
 }
 ```
 


### PR DESCRIPTION
The function existed briefly while I was developing #213, but it was removed before the PR was merged.