### PR TITLE
Replace WrapOptions with Into<Options>

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -93,7 +93,7 @@ impl<'a> Word<'a> {
 
         Word {
             word: trimmed,
-            width,
+            width: width,
             whitespace: &word[trimmed.len()..],
             penalty: "",
         }
@@ -125,7 +125,7 @@ impl<'a> Word<'a> {
                 if width > 0 && width + ch_width > line_width {
                     let word = Word {
                         word: &self.word[offset..idx],
-                        width,
+                        width: width,
                         whitespace: "",
                         penalty: "",
                     };
@@ -140,7 +140,7 @@ impl<'a> Word<'a> {
             if offset < self.word.len() {
                 let word = Word {
                     word: &self.word[offset..],
-                    width,
+                    width: width,
                     whitespace: self.whitespace,
                     penalty: self.penalty,
                 };

--- a/src/core.rs
+++ b/src/core.rs
@@ -232,14 +232,14 @@ pub fn find_words(line: &str) -> impl Iterator<Item = Word> {
 /// // The default splitter is HyphenSplitter:
 /// let options = Options::new(80);
 /// assert_eq!(
-///     split_words(vec![Word::from("foo-bar")], &&options).collect::<Vec<_>>(),
+///     split_words(vec![Word::from("foo-bar")], &options).collect::<Vec<_>>(),
 ///     vec![Word::from("foo-"), Word::from("bar")]
 /// );
 ///
 /// // The NoHyphenation splitter ignores the '-':
 /// let options = Options::new(80).splitter(NoHyphenation);
 /// assert_eq!(
-///     split_words(vec![Word::from("foo-bar")], &&options).collect::<Vec<_>>(),
+///     split_words(vec![Word::from("foo-bar")], &options).collect::<Vec<_>>(),
 ///     vec![Word::from("foo-bar")]
 /// );
 /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,7 @@ pub use crate::splitting::{HyphenSplitter, NoHyphenation, WordSplitter};
 pub mod core;
 
 /// Holds settings for wrapping and filling text.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct Options<'a, S = Box<dyn WordSplitter>> {
     /// The width in columns at which the text will be wrapped.
     pub width: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -360,7 +360,7 @@ impl<'a, S> Options<'a, S> {
             initial_indent: "",
             subsequent_indent: "",
             break_words: true,
-            splitter,
+            splitter: splitter,
         }
     }
 }
@@ -449,7 +449,7 @@ impl<'a, S: WordSplitter> Options<'a, S> {
             initial_indent: self.initial_indent,
             subsequent_indent: self.subsequent_indent,
             break_words: self.break_words,
-            splitter,
+            splitter: splitter,
         }
     }
 }
@@ -1078,14 +1078,16 @@ mod tests {
         let green_hello = "\u{1b}[0m\u{1b}[32mHello\u{1b}[0m";
         let blue_world = "\u{1b}[0m\u{1b}[34mWorld!\u{1b}[0m";
         assert_eq!(
-            fill(&format!("{} {}", green_hello, blue_world), 6),
-            format!("{}\n{}", green_hello, blue_world),
+            fill(&(String::from(green_hello) + " " + &blue_world), 6),
+            String::from(green_hello) + "\n" + &blue_world
         );
     }
 
     #[test]
     fn cloning_works() {
         static OPT: Options<HyphenSplitter> = Options::with_splitter(80, HyphenSplitter);
-        assert_eq!(OPT.width, 80);
+        #[allow(clippy::clone_on_copy)]
+        let opt = OPT.clone();
+        assert_eq!(opt.width, 80);
     }
 }

--- a/src/splitting.rs
+++ b/src/splitting.rs
@@ -47,6 +47,11 @@ impl<S: WordSplitter + ?Sized> WordSplitter for Box<S> {
     }
 }
 */
+impl<T: WordSplitter> WordSplitter for &T {
+    fn split_points(&self, word: &str) -> Vec<usize> {
+        (*self).split_points(word)
+    }
+}
 
 /// Use this as a [`Options.splitter`] to avoid any kind of
 /// hyphenation:
@@ -60,7 +65,7 @@ impl<S: WordSplitter + ?Sized> WordSplitter for Box<S> {
 /// ```
 ///
 /// [`Options.splitter`]: ../struct.Options.html#structfield.splitter
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct NoHyphenation;
 
 /// `NoHyphenation` implements `WordSplitter` by not splitting the
@@ -76,7 +81,7 @@ impl WordSplitter for NoHyphenation {
 ///
 /// You probably don't need to use this type since it's already used
 /// by default by `Options::new`.
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct HyphenSplitter;
 
 /// `HyphenSplitter` is the default `WordSplitter` used by


### PR DESCRIPTION
It's fairly confusing to have a struct and a nearly-identical trait. By centering everything around the concrete `Options` type, the relationship between `usize` and `Options` can be made more clear.