### PR TITLE
Introduce wrapping using an optimal-fit algorithm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ name = "linear"
 harness = false
 
 [dependencies]
+smawk = "0.3"
 unicode-width = "0.1"
 terminal_size = { version = "0.1", optional = true }
 hyphenation = { version = "0.8", optional = true, features = ["embed_en-us"] }

--- a/benches/linear.rs
+++ b/benches/linear.rs
@@ -23,12 +23,28 @@ pub fn benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("String lengths");
     for length in [100, 200, 400, 800, 1600, 3200, 6400].iter() {
         let text = lorem_ipsum(*length);
-        let options = textwrap::Options::new(LINE_LENGTH);
-        group.bench_with_input(BenchmarkId::new("fill", length), &text, |b, text| {
-            b.iter(|| textwrap::fill(text, &options));
-        });
+        let options = textwrap::Options::new(LINE_LENGTH)
+            .wrap_algorithm(textwrap::core::WrapAlgorithm::OptimalFit);
+        group.bench_with_input(
+            BenchmarkId::new("fill_optimal_fit", length),
+            &text,
+            |b, text| {
+                b.iter(|| textwrap::fill(text, &options));
+            },
+        );
 
-        let options: textwrap::Options = options.splitter(Box::new(textwrap::HyphenSplitter));
+        let options = textwrap::Options::new(LINE_LENGTH)
+            .wrap_algorithm(textwrap::core::WrapAlgorithm::FirstFit);
+        group.bench_with_input(
+            BenchmarkId::new("fill_first_fit", length),
+            &text,
+            |b, text| {
+                b.iter(|| textwrap::fill(text, &options));
+            },
+        );
+
+        let options: textwrap::Options =
+            textwrap::Options::new(LINE_LENGTH).splitter(Box::new(textwrap::HyphenSplitter));
         group.bench_with_input(BenchmarkId::new("fill_boxed", length), &text, |b, text| {
             b.iter(|| textwrap::fill(text, &options));
         });

--- a/examples/interactive.rs
+++ b/examples/interactive.rs
@@ -19,6 +19,7 @@ mod unix_only {
     use termion::raw::{IntoRawMode, RawTerminal};
     use termion::screen::AlternateScreen;
     use termion::{color, cursor, style};
+    use textwrap::core::WrapAlgorithm::{FirstFit, OptimalFit};
     use textwrap::{wrap, HyphenSplitter, NoHyphenation, Options, WordSplitter};
 
     #[cfg(feature = "hyphenation")]
@@ -97,6 +98,16 @@ mod unix_only {
             cursor::Goto(left_col, left_row),
             style::Bold,
             splitter_label,
+            style::Reset,
+        )?;
+        left_row += 1;
+
+        write!(
+            stdout,
+            "{}- algorithm: {}{:?}{} (toggle with Ctrl-o)",
+            cursor::Goto(left_col, left_row),
+            style::Bold,
+            options.wrap_algorithm,
             style::Reset,
         )?;
         left_row += 1;
@@ -232,6 +243,12 @@ mod unix_only {
                 Key::Left => options.width = options.width.saturating_sub(1),
                 Key::Right => options.width = options.width.saturating_add(1),
                 Key::Ctrl('b') => options.break_words = !options.break_words,
+                Key::Ctrl('o') => {
+                    options.wrap_algorithm = match options.wrap_algorithm {
+                        OptimalFit => FirstFit,
+                        FirstFit => OptimalFit,
+                    }
+                }
                 Key::Ctrl('s') => {
                     let idx = idx_iter.next().unwrap();
                     std::mem::swap(&mut options.splitter, &mut splitters[idx]);

--- a/src/core.rs
+++ b/src/core.rs
@@ -5,6 +5,7 @@
 //! [`fill`](super::fill) function don't do what you want.
 
 use crate::{Options, WordSplitter};
+use std::cell::RefCell;
 use unicode_width::UnicodeWidthChar;
 use unicode_width::UnicodeWidthStr;
 
@@ -156,18 +157,21 @@ impl<'a> Word<'a> {
 }
 
 impl Fragment for Word<'_> {
+    #[inline]
     fn width(&self) -> usize {
         self.width
     }
 
     // We assume the whitespace consist of ' ' only. This allows us to
     // compute the display width in constant time.
+    #[inline]
     fn whitespace_width(&self) -> usize {
         self.whitespace.len()
     }
 
     // We assume the penalty is `""` or `"-"`. This allows us to
     // compute the display width in constant time.
+    #[inline]
     fn penalty_width(&self) -> usize {
         self.penalty.len()
     }
@@ -305,14 +309,85 @@ where
     shortened_words
 }
 
-/// Wrap abstract fragments into lines of different widths.
+/// Wrapping algorithms.
 ///
-/// The `line_widths` maps the line number to the desired width. This
-/// can be used to implement hanging indentation.
+/// After a text has been broken into [`Fragment`]s, the one now has
+/// to decide how to break the fragments into lines. The simplest
+/// algorithm for this is implemented by [`wrap_first_fit`]: it uses
+/// no look-ahead and simply adds fragments to the line as long as
+/// they fit. However, this can lead to poor line breaks if a large
+/// fragment almost-but-not-quite fits on a line. When that happens,
+/// the fragment is moved to the next line and it will leave behind a
+/// large gap. A more advanced algorithm, implemented by
+/// [`wrap_optimal_fit`], will take this into account. The optimal-fit
+/// algorithm considers all possible line breaks and will attempt to
+/// minimize the gaps left behind by overly short lines.
+///
+/// While both algorithms run in linear time, the first-fit algorithm
+/// is about 4 times faster than the optimal-fit algorithm.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum WrapAlgorithm {
+    /// Use an advanced algorithm which considers the entire paragraph
+    /// to find optimal line breaks. Implemented by
+    /// [`wrap_optimal_fit`].
+    OptimalFit,
+    /// Use a fast and simple algorithm with no look-ahead to find
+    /// line breaks. Implemented by [`wrap_first_fit`].
+    FirstFit,
+}
+
+/// Wrap abstract fragments into lines with a first-fit algorithm.
+///
+/// The `line_widths` map line numbers (starting from 0) to a target
+/// line width. This can be used to implement hanging indentation.
 ///
 /// The fragments must already have been split into the desired
 /// widths, this function will not (and cannot) attempt to split them
 /// further when arranging them into lines.
+///
+/// # First-Fit Algorithm
+///
+/// This implements a simple “greedy” algorithm: accumulate fragments
+/// one by one and when a fragment no longer fits, start a new line.
+/// There is no look-ahead, we simply take first fit of the fragments
+/// we find.
+///
+/// While fast and predictable, this algorithm can produce poor line
+/// breaks when a long fragment is moved to a new line, leaving behind
+/// a large gap:
+///
+/// ```
+/// use textwrap::core::{find_words, wrap_first_fit, wrap_optimal_fit, Word};
+///
+/// // Helper to convert wrapped lines to a Vec<String>.
+/// fn lines_to_strings(lines: Vec<&[Word<'_>]>) -> Vec<String> {
+///     lines.iter().map(|line| {
+///         line.iter().map(|word| &**word).collect::<Vec<_>>().join(" ")
+///     }).collect::<Vec<_>>()
+/// }
+///
+/// let text = "These few words will unfortunately not wrap nicely.";
+/// let words = find_words(text).collect::<Vec<_>>();
+/// assert_eq!(lines_to_strings(wrap_first_fit(&words, |_| 15)),
+///            vec!["These few words",
+///                 "will",  // <-- short line
+///                 "unfortunately",
+///                 "not wrap",
+///                 "nicely."]);
+///
+/// // We can avoid the short line if we look ahead:
+/// assert_eq!(lines_to_strings(wrap_optimal_fit(&words, |_| 15)),
+///            vec!["These few",
+///                 "words will",
+///                 "unfortunately",
+///                 "not wrap",
+///                 "nicely."]);
+/// ```
+///
+/// The [`wrap_optimal_fit`] function was used above to get better
+/// line breaks. It uses an advanced algorithm which tries to avoid
+/// short lines. This function is about 4 times faster than
+/// [`wrap_optimal_fit`].
 ///
 /// # Examples
 ///
@@ -330,7 +405,7 @@ where
 /// on your estimates. You can model this with a program like this:
 ///
 /// ```
-/// use textwrap::core::{wrap_fragments, Fragment};
+/// use textwrap::core::{wrap_first_fit, Fragment};
 ///
 /// #[derive(Debug)]
 /// struct Task<'a> {
@@ -361,7 +436,7 @@ where
 ///
 /// fn assign_days<'a>(tasks: &[Task<'a>], day_length: usize) -> Vec<(usize, Vec<&'a str>)> {
 ///     let mut days = Vec::new();
-///     for day in wrap_fragments(&tasks, |i| day_length) {
+///     for day in wrap_first_fit(&tasks, |i| day_length) {
 ///         let last = day.last().unwrap();
 ///         let work_hours: usize = day.iter().map(|t| t.hours + t.sweep).sum();
 ///         let names = day.iter().map(|t| t.name).collect::<Vec<_>>();
@@ -396,7 +471,7 @@ where
 ///
 /// Apologies to anyone who actually knows how to build a house and
 /// knows how long each step takes :-)
-pub fn wrap_fragments<T: Fragment, F: Fn(usize) -> usize>(
+pub fn wrap_first_fit<T: Fragment, F: Fn(usize) -> usize>(
     fragments: &[T],
     line_widths: F,
 ) -> Vec<&[T]> {
@@ -414,6 +489,227 @@ pub fn wrap_fragments<T: Fragment, F: Fn(usize) -> usize>(
         width += fragment.width() + fragment.whitespace_width();
     }
     lines.push(&fragments[start..]);
+    lines
+}
+
+/// Cache for line numbers. This is necessary to avoid a O(n**2)
+/// behavior when computing line numbers in [`wrap_optimal_fit`].
+struct LineNumbers {
+    line_numbers: RefCell<Vec<usize>>,
+}
+
+impl LineNumbers {
+    fn new(size: usize) -> Self {
+        let mut line_numbers = Vec::with_capacity(size);
+        line_numbers.push(0);
+        LineNumbers {
+            line_numbers: RefCell::new(line_numbers),
+        }
+    }
+
+    fn get(&self, i: usize, minima: &[(usize, i32)]) -> usize {
+        while self.line_numbers.borrow_mut().len() < i + 1 {
+            let pos = self.line_numbers.borrow().len();
+            let line_number = 1 + self.get(minima[pos].0, &minima);
+            self.line_numbers.borrow_mut().push(line_number);
+        }
+
+        self.line_numbers.borrow()[i]
+    }
+}
+
+/// Per-line penalty. This is added for every line, which makes it
+/// expensive to output more lines than the minimum required.
+const NLINE_PENALTY: i32 = 1000;
+
+/// Per-character cost for lines that overflow the target line width.
+///
+/// With a value of 50², every single character costs as much as
+/// leaving a gap of 50 characters behind. This is becuase we assign
+/// as cost of `gap * gap` to a short line. This means that we can
+/// overflow the line by 1 character in extreme cases:
+///
+/// ```
+/// use textwrap::core::{wrap_optimal_fit, Word};
+///
+/// let short = "foo ";
+/// let long = "x".repeat(50);
+/// let fragments = vec![Word::from(short), Word::from(&long)];
+///
+/// // Perfect fit, both words are on a single line with no overflow.
+/// let wrapped = wrap_optimal_fit(&fragments, |_| short.len() + long.len());
+/// assert_eq!(wrapped, vec![&[Word::from(short), Word::from(&long)]]);
+///
+/// // The words no longer fit, yet we get a single line back. While
+/// // the cost of overflow (`1 * 2500`) is the same as the cost of the
+/// // gap (`50 * 50 = 2500`), the tie is broken by `NLINE_PENALTY`
+/// // which makes it cheaper to overflow than to use two lines.
+/// let wrapped = wrap_optimal_fit(&fragments, |_| short.len() + long.len() - 1);
+/// assert_eq!(wrapped, vec![&[Word::from(short), Word::from(&long)]]);
+///
+/// // The cost of overflow would be 2 * 2500, whereas the cost of the
+/// // gap is only `49 * 49 + NLINE_PENALTY = 2401 + 1000 = 3401`. We
+/// // therefore get two lines.
+/// let wrapped = wrap_optimal_fit(&fragments, |_| short.len() + long.len() - 2);
+/// assert_eq!(wrapped, vec![&[Word::from(short)],
+///                          &[Word::from(&long)]]);
+/// ```
+///
+/// This only happens if the overflowing word is 50 characters long
+/// _and_ if it happens to overflow the line by exactly one character.
+/// If it overflows by more than one character, the overflow penalty
+/// will quickly outgrow the cost of the gap, as seen above.
+const OVERFLOW_PENALTY: i32 = 50 * 50;
+
+/// The last line is short if it is less than 1/4 of the target width.
+const SHORT_LINE_FRACTION: usize = 4;
+
+/// Penalize a short last line.
+const SHORT_LAST_LINE_PENALTY: i32 = 25;
+
+/// Penalty for lines ending with a hyphen.
+const HYPHEN_PENALTY: i32 = 25;
+
+/// Wrap abstract fragments into lines with an optimal-fit algorithm.
+///
+/// The `line_widths` map line numbers (starting from 0) to a target
+/// line width. This can be used to implement hanging indentation.
+///
+/// The fragments must already have been split into the desired
+/// widths, this function will not (and cannot) attempt to split them
+/// further when arranging them into lines.
+///
+/// # Optimal-Fit Algorithm
+///
+/// The algorithm considers all possible break points and picks the
+/// breaks which minimizes the gaps at the end of each line. More
+/// precisely, the algorithm assigns a cost or penalty to each break
+/// point, determined by `cost = gap * gap` where `gap = target_width -
+/// line_width`. Shorter lines are thus penalized more heavily since
+/// they leave behind a larger gap.
+///
+/// We can illustrate this with the text “To be, or not to be: that is
+/// the question”. We will be wrapping it in a narrow column with room
+/// for only 10 characters. The [greedy algorithm](wrap_first_fit)
+/// will produce these lines, each annotated with the corresponding
+/// penalty:
+///
+/// ```text
+/// "To be, or"   1² =  1
+/// "not to be:"  0² =  0
+/// "that is"     3² =  9
+/// "the"         7² = 49
+/// "question"    2² =  4
+/// ```
+///
+/// We see that line four with “the” leaves a gap of 7 columns, which
+/// gives it a penalty of 49. The sum of the penalties is 63.
+///
+/// There are 10 words, which means that there are `2_u32.pow(9)` or
+/// 512 different ways to typeset it. We can compute
+/// the sum of the penalties for each possible line break and search
+/// for the one with the lowest sum:
+///
+/// ```text
+/// "To be,"     4² = 16
+/// "or not to"  1² =  1
+/// "be: that"   2² =  4
+/// "is the"     4² = 16
+/// "question"   2² =  4
+/// ```
+///
+/// The sum of the penalties is 41, which is better than what the
+/// greedy algorithm produced.
+///
+/// Searching through all possible combinations would normally be
+/// prohibitively slow. However, it turns out that the problem can be
+/// formulated as the task of finding column minima in a cost matrix.
+/// This matrix has a special form (totally monotone) which lets us
+/// use a [linear-time algorithm called
+/// SMAWK](https://lib.rs/crates/smawk) to find the optimal break
+/// points.
+///
+/// This means that the time complexity remains O(_n_) where _n_ is
+/// the number of words. Compared to [`wrap_first_fit`], this function
+/// is about 4 times slower.
+///
+/// The use of penalties is inspired by the line breaking algorithm
+/// used TeX, described in the 1981 article [_Breaking Paragraphs into
+/// Lines_](http://www.eprg.org/G53DOC/pdfs/knuth-plass-breaking.pdf)
+/// by Knuth and Plass. The implementation here is based on [Python
+/// code by David
+/// Eppstein](https://github.com/jfinkels/PADS/blob/master/pads/wrap.py).
+pub fn wrap_optimal_fit<'a, T: Fragment, F: Fn(usize) -> usize>(
+    fragments: &'a [T],
+    line_widths: F,
+) -> Vec<&'a [T]> {
+    let mut widths = Vec::with_capacity(fragments.len() + 1);
+    let mut width = 0;
+    widths.push(width);
+    for fragment in fragments {
+        width += fragment.width() + fragment.whitespace_width();
+        widths.push(width);
+    }
+
+    let line_numbers = LineNumbers::new(fragments.len());
+
+    let minima = smawk::online_column_minima(0, widths.len(), |values, i, j| {
+        // Line number for fragment `i`.
+        let line_number = line_numbers.get(i, &values);
+        let target_width = std::cmp::max(1, line_widths(line_number));
+
+        // Compute the width of a line spanning fragments[i..j] in
+        // constant time. We need to adjust widths[j] by subtracting
+        // the whitespace of fragment[j-i] and then add the penalty.
+        let line_width = widths[j] - widths[i] - fragments[j - 1].whitespace_width()
+            + fragments[j - 1].penalty_width();
+
+        // We compute cost of the line containing fragments[i..j]. We
+        // start with values[i].1, which is the optimal cost for
+        // breaking before fragments[i].
+        //
+        // First, every extra line cost NLINE_PENALTY.
+        let mut cost = values[i].1 + NLINE_PENALTY;
+
+        // Next, we add a penalty depending on the line length.
+        if line_width > target_width {
+            // Lines that overflow get a hefty penalty.
+            let overflow = (line_width - target_width) as i32;
+            cost += overflow * OVERFLOW_PENALTY;
+        } else if j < fragments.len() {
+            // Other lines (except for the last line) get a milder
+            // penalty which depend on the size of the gap.
+            let gap = (target_width - line_width) as i32;
+            cost += gap * gap;
+        } else if i + 1 == j && line_width < target_width / SHORT_LINE_FRACTION {
+            // The last line can have any size gap, but we do add a
+            // penalty if the line is very short (typically because it
+            // contains just a single word).
+            cost += SHORT_LAST_LINE_PENALTY;
+        }
+
+        // Finally, we discourage hyphens.
+        if fragments[j - 1].penalty_width() > 0 {
+            // TODO: this should use a penalty value from the fragment
+            // instead.
+            cost += HYPHEN_PENALTY;
+        }
+
+        cost
+    });
+
+    let mut lines = Vec::with_capacity(line_numbers.get(fragments.len(), &minima));
+    let mut pos = fragments.len();
+    loop {
+        let prev = minima[pos].0;
+        lines.push(&fragments[prev..pos]);
+        pos = prev;
+        if pos == 0 {
+            break;
+        }
+    }
+
+    lines.reverse();
     lines
 }
 


### PR DESCRIPTION
This PR introduces a new wrapping algorithm which finds a globally optimal set of line breaks, taking certain penalties into account. This is inspired by the line breaking algorithm used TeX, described in the 1981 article [_Breaking Paragraphs into Lines_][1] by Knuth and Plass. The implementation here is based on [Python code by David Eppstein][2].

The wrapping algorithm which we’ve been using until now is a “greedy” or “first fit” algorithm with no look-ahead. It simply accumulates words until no more fit on the line. While simple and predictable, this algorithm can produce poor line breaks when a long word is moved to a new line, leaving behind a large gap.

The new “optimal fit” algorithm considers all possible break points and picks the breaks which minimizes the gaps at the end of each line. More precisely, the algorithm assigns a penalty to a break point, determined by `(target_width - line_width)**2`. As an example, if you’re wrapping at 80 columns, a line with 78 characters has a penalty of 4, but a line that with only 75 characters has a penalty of 25. Shorter lines are thus penalized more heavily.

The overall optimization minimizes the sum of the squares. The effect is that the algorithm will move short words down to subsequent lines if it lowers the total cost for the paragraph. This can be seen in action if we wrap the text “To be, or not to be: that is the question” in a narrow column with room for only 10 characters.

The greedy algorithm will produce these lines, each annotated with the corresponding penalty:

    "To be, or"   1² =  1
    "not to be:"  0² =  0
    "that is"     3² =  9
    "the"         7² = 49
    "question"    2² =  4

We see that line four with “the” leaves a gap of 7 columns, which gives it a penalty of 49. The sum of the penalties is 63.

With an optimal wrapping algorithm, the first line is shortened in order to ensure that line four has a smaller gap:

    "To be,"     4² = 16
    "or not to"  1² =  1
    "be: that"   2² =  4
    "is the"     4² = 16
    "question"   2² =  4

This time the sum of the penalties is 41, so the algorithm will prefer these break points over the first ones.

The full algorithm is slightly more complex than this, e.g., lines longer than the line width are penalized heavily to suppress them. Additionally, hyphens are penalized to ensure they only occur when they improve the breaks substantially.

If a paragraph has `n` places where line breaks can occur, there are potentially `2**n` different ways to typeset it. Searching through all possible combinations would be prohibitively slow. However, it turns out that the problem can be formulated as the task of finding column minima in a cost matrix. This matrix has a special form (totally monotone) which lets us use a linear-time algorithm called SMAWK[3] to find the optimal break points.

This means that the time complexity remains O(n) where n is the number of words.

Benchmarking shows that wrapping a very long paragraph with ~300 words or 1600 characters take ~3.5 times as long as before. The first-fit algorithm took 19 microseconds, optimal-fit takes 72 microseconds. This seems more than fast enough, and I’ve thus made the optimal-fit algorithm the default. If desired, the best-fit algorithm can still be selected.

[1]: http://www.eprg.org/G53DOC/pdfs/knuth-plass-breaking.pdf
[2]: https://github.com/jfinkels/PADS/blob/master/pads/wrap.py
[3]: https://lib.rs/crates/smawk