### PR TITLE
Run rustdoc to check for broken intra-doc links in our documentation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,3 +53,8 @@ jobs:
 
       - name: Run tests
         run: cargo test --all-features
+
+      - name: Build documentation
+        env:
+          RUSTDOCFLAGS: --deny broken_intra_doc_links
+        run: cargo doc --all-features --no-deps


### PR DESCRIPTION
This adds a `cargo doc` step to the CI workflow. It will error out if we have broken intra-doc links.