### PR TITLE
Add more intermediate steps to linear benchmark

### DIFF
--- a/benches/linear.rs
+++ b/benches/linear.rs
@@ -21,7 +21,7 @@ fn lorem_ipsum(length: usize) -> String {
 
 pub fn benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("String lengths");
-    for length in [100, 200, 400, 800, 1600, 3200, 6400].iter() {
+    for length in [200, 300, 400, 600, 800, 1200, 1600, 2400, 3200, 4800, 6400].iter() {
         let text = lorem_ipsum(*length);
         let options = textwrap::Options::new(LINE_LENGTH)
             .wrap_algorithm(textwrap::core::WrapAlgorithm::OptimalFit);


### PR DESCRIPTION
The size of the input now grow by +100 twice, by +200 twice, and so on. This creates nicer results since the steps are less spaced out.