### PR TITLE
Show build type (debug/release) in interactive demo

### DIFF
--- a/examples/interactive.rs
+++ b/examples/interactive.rs
@@ -129,6 +129,20 @@ mod unix_only {
 
         write!(
             stdout,
+            "{}- build: {}{}{}",
+            cursor::Goto(right_col, right_row),
+            style::Bold,
+            if cfg!(debug_assertions) {
+                "debug"
+            } else {
+                "release"
+            },
+            style::Reset,
+        )?;
+        right_row += 1;
+
+        write!(
+            stdout,
             "{}- words: {}{}{}",
             cursor::Goto(right_col, right_row),
             style::Bold,


### PR DESCRIPTION
I was surprised when I suddenly saw that the latency was ~3500 usec on a small demo text. It turned out I was looking at a debug build instead of a release build :)