### PR TITLE
Exclude benchmarks and examples from published crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["text", "formatting", "wrap", "typesetting", "hyphenation"]
 categories = ["text-processing", "command-line-interface"]
 license = "MIT"
 edition = "2018"
+exclude = [".github/", ".gitignore", "benches/", "examples/"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
These files are meant to be used by people who clone the repository. From [a discussion on users.rust-lang.org][1], it seems that tests can be useful so they’re left in the published crate.

[1]: https://users.rust-lang.org/t/what-to-include-when-publishing-a-crate/51992?u=mgeisler