### PR TITLE
Introduce fuzz tests for wrap_optimal_fit and wrap_first_fit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["text", "formatting", "wrap", "typesetting", "hyphenation"]
 categories = ["text-processing", "command-line-interface"]
 license = "MIT"
 edition = "2018"
-exclude = [".github/", ".gitignore", "benches/", "examples/"]
+exclude = [".github/", ".gitignore", "benches/", "examples/", "fuzz/"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,3 @@
+artifacts/
+corpus/
+target/

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,30 @@
+
+[package]
+name = "textwrap-fuzz"
+version = "0.0.0"
+authors = ["Automatically generated"]
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.3"
+textwrap = { path = ".." }
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "fill_optimal_fit"
+path = "fuzz_targets/fill_optimal_fit.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fill_first_fit"
+path = "fuzz_targets/fill_first_fit.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/fill_first_fit.rs
+++ b/fuzz/fuzz_targets/fill_first_fit.rs
@@ -1,0 +1,9 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use textwrap::core::WrapAlgorithm::FirstFit;
+use textwrap::Options;
+
+fuzz_target!(|input: (String, usize)| {
+    let options = Options::new(input.1).wrap_algorithm(FirstFit);
+    let _ = textwrap::fill(&input.0, &options);
+});

--- a/fuzz/fuzz_targets/fill_optimal_fit.rs
+++ b/fuzz/fuzz_targets/fill_optimal_fit.rs
@@ -1,0 +1,9 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use textwrap::core::WrapAlgorithm::OptimalFit;
+use textwrap::Options;
+
+fuzz_target!(|input: (String, usize)| {
+    let options = Options::new(input.1).wrap_algorithm(OptimalFit);
+    let _ = textwrap::fill(&input.0, &options);
+});


### PR DESCRIPTION
These fuzz tests immediately found the problem reported in #247 and gave a short way of reproducing it:

    wrap("x y", 515566821223)

will currently panic due to an overflow error. This is because the gap after `"x"` is enourmous, large enough to make `cost += gap * gap` overflow the `i32` type currently used for the cost computations.

The `wrap_first_fit` function seems to not crash.

Run the fuzz tests with:

    $ cargo fuzz run fill_optimal_fit -- -only_ascii=1

You’ll need to `cargo install cargo-fuzz` first.