### PR TITLE
Implement wrapping functions as iterators

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -953,12 +953,14 @@ where
         // The last fragment of the range fragments[i..j].
         let last_fragment = &fragments[j - 1];
 
+        // The cumulative width before fragments[i]. This is the cumulative width before the
+        // fragment `i`, or if `i` is the first fragment, zero.
+        let start_cu_width = i.checked_sub(1).map(|i| fragments[i].cu_width).unwrap_or(0);
+
         // Compute the width of a line spanning fragments[i..j] in
         // constant time. We need to adjust widths[j] by subtracting
         // the whitespace of fragment[j-i] and then add the penalty.
-        let line_width = last_fragment.cu_width
-            - i.checked_sub(1).map(|i| fragments[i].cu_width).unwrap_or(0)
-            - last_fragment.whitespace_width
+        let line_width = last_fragment.cu_width - start_cu_width - last_fragment.whitespace_width
             + last_fragment.penalty_width;
 
         // We compute cost of the line containing fragments[i..j]. We

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -764,7 +764,6 @@ where
 /// Please see the [`linear`
 /// benchmark](https://github.com/mgeisler/textwrap/blob/master/benches/linear.rs)
 /// for details.
-// TODO: Make this take an &mut str
 pub fn fill_inplace(text: &mut String, width: usize) {
     let mut indices = Vec::new();
 


### PR DESCRIPTION
This is the first mergeable PR using the ideas from #244.

Motivation:
- `no_std`. The current implementation of `wrap_first_fit` does not require allocation at any stage, and so can be used in `no_std` contexts if we support that in the future.
- Avoiding allocations for the return value, for efficency/performance reasons.
- Wrapping without creating a slice. `wrap_first_fit` and `wrap_optimal_fit` now do not require the fragments to be stored contiguously, and instead simply require any iterator over fragments. This is done without losing any performance (in theory at least). This allows piping the result of splitting functions directly into wrapping functions without collecting into a vector first.
- Owned data. It is more flexible to return owned fragments from these functions rather than subslices, as with slices it forces the data to be immutable.

Implementation notes:
- I had to implement `Fragment` for `&F` so that passing a slice into `wrap_first_fit` won't break (as iterating over a slice produces references).
- The `WrapFirstFit` and `WrapOptimalFit` iterators iterate over `(F, bool)` tuples where the bool indicates whether it's the last fragment of its line; from experience of porting this library's code and tests to the new system it is about equally easy to use.