### PR TITLE
Handle overflows in `wrap_optimal_fit` by divide-and-conquer

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 cargo-fuzz = true
 
 [dependencies]
-libfuzzer-sys = "0.3"
+libfuzzer-sys = { version = "0.3", features = ["arbitrary-derive"] }
 textwrap = { path = ".." }
 
 # Prevent this from interfering with workspaces
@@ -26,5 +26,11 @@ doc = false
 [[bin]]
 name = "fill_first_fit"
 path = "fuzz_targets/fill_first_fit.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "wrap_optimal_fit"
+path = "fuzz_targets/wrap_optimal_fit.rs"
 test = false
 doc = false

--- a/fuzz/fuzz_targets/wrap_optimal_fit.rs
+++ b/fuzz/fuzz_targets/wrap_optimal_fit.rs
@@ -1,0 +1,30 @@
+#![no_main]
+use libfuzzer_sys::{arbitrary, fuzz_target};
+use textwrap::core;
+use textwrap::core::Fragment;
+
+#[derive(arbitrary::Arbitrary, Debug, Eq, PartialEq, Clone)]
+struct BoxGluePenalty(usize, usize, usize);
+
+#[rustfmt::skip]
+impl core::Fragment for BoxGluePenalty {
+    fn width(&self) -> usize { self.0 }
+    fn whitespace_width(&self) -> usize { self.1 }
+    fn penalty_width(&self) -> usize { self.2 }
+}
+
+fuzz_target!(|input: (Vec<BoxGluePenalty>, u64)| {
+    let line_width = input.1 as usize;
+    let fragments = input.0.clone();
+
+    let total_width: Option<usize> = fragments.iter().fold(Some(0), |sum, f| {
+        sum.and_then(|sum| sum.checked_add(f.width()))
+            .and_then(|sum| sum.checked_add(f.whitespace_width()))
+            .and_then(|sum| sum.checked_add(f.penalty_width()))
+    });
+    if total_width.is_none() {
+        return;
+    }
+
+    let _ = core::wrap_optimal_fit(&fragments, &|_| line_width);
+});

--- a/fuzz/fuzz_targets/wrap_optimal_fit.rs
+++ b/fuzz/fuzz_targets/wrap_optimal_fit.rs
@@ -23,6 +23,8 @@ fuzz_target!(|input: (Vec<BoxGluePenalty>, u64)| {
             .and_then(|sum| sum.checked_add(f.penalty_width()))
     });
     if total_width.is_none() {
+        // The total width overflows usize — this is not supported so
+        // return here to avoid a crash.
         return;
     }
 

--- a/src/core/optimal_fit.rs
+++ b/src/core/optimal_fit.rs
@@ -151,6 +151,11 @@ const HYPHEN_PENALTY: usize = 25;
 /// code by David
 /// Eppstein](https://github.com/jfinkels/PADS/blob/master/pads/wrap.py).
 ///
+/// # Panics
+///
+/// The total width of all fragments must fit inside an `usize`
+/// (including the whitespace and penalty widths).
+///
 /// **Note:** Only available when the `smawk` Cargo feature is
 /// enabled.
 pub fn wrap_optimal_fit<'a, T: Fragment, F: Fn(usize) -> usize>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -945,8 +945,13 @@ mod tests {
     }
 
     #[test]
-    fn max_width() {
+    fn max_width_usize() {
         assert_eq!(wrap("foo bar", usize::max_value()), vec!["foo bar"]);
+    }
+
+    #[test]
+    fn max_width_usize_issue_247() {
+        assert_eq!(wrap("x y", 515566821223), vec!["x y"]);
     }
 
     #[test]


### PR DESCRIPTION
The `wrap_optimal_fit algorithm` computes the penalty for a gap as `gap * gap`. If a fragment has a size near `usize::max_value()` and if the line width is small, this computation can easily overflow.

When this happened, we would previously abort or unwind. Now, we instead do the computations with checked arithmetic and detect the overflow. We then proceed to wrap the half of the fragments by themselves. If this work, we then wrap the second half. This way, we might be able to wrap everything without overflow.

Should there be a single fragment which causes the overflow by itself, this fragment is put on a line by itself.

When wrapping part of the fragments, we might of course end up with a partial last line. To fix this, we simply pop this line and re-wrap the fragments that were put onto this line. This ensures no “seams” in the wrapping.

Fixes #247.