### PR TITLE
Remove uninteresting fill_boxed and fill_usize benchmarks

### DIFF
--- a/benches/linear.rs
+++ b/benches/linear.rs
@@ -43,16 +43,6 @@ pub fn benchmark(c: &mut Criterion) {
             },
         );
 
-        let options: textwrap::Options =
-            textwrap::Options::new(LINE_LENGTH).splitter(Box::new(textwrap::HyphenSplitter));
-        group.bench_with_input(BenchmarkId::new("fill_boxed", length), &text, |b, text| {
-            b.iter(|| textwrap::fill(text, &options));
-        });
-
-        group.bench_with_input(BenchmarkId::new("fill_usize", length), &text, |b, text| {
-            b.iter(|| textwrap::fill(text, LINE_LENGTH));
-        });
-
         group.bench_function(BenchmarkId::new("fill_inplace", length), |b| {
             b.iter_batched(
                 || text.clone(),


### PR DESCRIPTION
I thought these benchmarks would tell me interesting things about how using an `usize` for `Options` would give all sorts of inlining benefits. In reality, I cannot measure any difference in performance between these benchmarks, so we might as well remove them.

This has the benefit that one can do

    $ cargo bench /2400

to quickly run the remaining benchmarks with a given string length.