### PR TITLE
Link directly to dependencies in docstrings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,7 +151,10 @@
 //!   [hyphenation] crate. See the [`WordSplitter`] trait for details.
 //!
 //! [unicode-width]: https://docs.rs/unicode-width/
+//! [smawk]: https://docs.rs/smawk/
 //! [textwrap-macros]: https://docs.rs/textwrap-macros/
+//! [terminal_size]: https://docs.rs/terminal_size/
+//! [hyphenation]: https://docs.rs/hyphenation/
 
 #![doc(html_root_url = "https://docs.rs/textwrap/0.13.1")]
 #![forbid(unsafe_code)] // See https://github.com/mgeisler/textwrap/issues/210

--- a/src/splitting.rs
+++ b/src/splitting.rs
@@ -31,6 +31,8 @@
 ///
 /// Please see the documentation for the [hyphenation] crate for more
 /// details.
+///
+/// [hyphenation]: https://docs.rs/hyphenation/
 pub trait WordSplitter: std::fmt::Debug {
     /// Return all possible indices where `word` can be split.
     ///
@@ -127,6 +129,8 @@ impl WordSplitter for HyphenSplitter {
 ///
 /// **Note:** Only available when the `hyphenation` feature is
 /// enabled.
+///
+/// [hyphenation]: https://docs.rs/hyphenation/
 #[cfg(feature = "hyphenation")]
 impl WordSplitter for hyphenation::Standard {
     fn split_points(&self, word: &str) -> Vec<usize> {


### PR DESCRIPTION
This ensures that the links work regardless of how `cargo doc` is
invoked.