### PR TITLE
Make smawk Cargo feature optional in benchmarks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,8 +54,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Build all targets
+      - name: Build all targets with default features
         run: cargo build --all-targets
+
+      - name: Build all targets without default features
+        run: cargo build --all-targets --no-default-features
 
       - name: Build all targets with all features
         run: cargo build --all-targets --all-features

--- a/benches/linear.rs
+++ b/benches/linear.rs
@@ -23,15 +23,19 @@ pub fn benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("String lengths");
     for length in [200, 300, 400, 600, 800, 1200, 1600, 2400, 3200, 4800, 6400].iter() {
         let text = lorem_ipsum(*length);
-        let options = textwrap::Options::new(LINE_LENGTH)
-            .wrap_algorithm(textwrap::core::WrapAlgorithm::OptimalFit);
-        group.bench_with_input(
-            BenchmarkId::new("fill_optimal_fit", length),
-            &text,
-            |b, text| {
-                b.iter(|| textwrap::fill(text, &options));
-            },
-        );
+
+        #[cfg(feature = "smawk")]
+        {
+            let options = textwrap::Options::new(LINE_LENGTH)
+                .wrap_algorithm(textwrap::core::WrapAlgorithm::OptimalFit);
+            group.bench_with_input(
+                BenchmarkId::new("fill_optimal_fit", length),
+                &text,
+                |b, text| {
+                    b.iter(|| textwrap::fill(text, &options));
+                },
+            );
+        }
 
         let options = textwrap::Options::new(LINE_LENGTH)
             .wrap_algorithm(textwrap::core::WrapAlgorithm::FirstFit);


### PR DESCRIPTION
Also test that we can build all targets with `--no-default-features`.