### PR TITLE
Include benches/ again

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["text", "formatting", "wrap", "typesetting", "hyphenation"]
 categories = ["text-processing", "command-line-interface"]
 license = "MIT"
 edition = "2018"
-exclude = [".github/", ".gitignore", "benches/", "examples/", "fuzz/"]
+exclude = [".github/", ".gitignore", "examples/", "fuzz/"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Publishing with the `benches/` directory excluded results in an error message since the benchmark cannot be found:

```
% cargo publish --dry-run
    Updating crates.io index
   Packaging textwrap v0.13.1 (/home/mg/src/textwrap)
   Verifying textwrap v0.13.1 (/home/mg/src/textwrap)
error: failed to verify package tarball

Caused by:
  failed to parse manifest at `/home/mg/src/textwrap/target/package/textwrap-0.13.1/Cargo.toml`

Caused by:
  can't find `linear` bench, specify bench.path
```

Until this is resolved, we'll just include the ~4 KB benchmark in the crate. See the [discussion on URLO](https://users.rust-lang.org/t/cargo-publish-with-excluded-benchmark-fails-validation/53444?u=mgeisler).