### PR TITLE
Include a dependency graph in the generated documentation

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -46,6 +46,30 @@ jobs:
           git config user.name "Martin Geisler"
           git config user.email "martin@geisler.net"
 
+      - name: Install Graphviz
+        uses: ts-graphviz/setup-graphviz@v1
+
+      # We use debug builds since they compile a little faster.
+      - name: Install cargo-depgraph
+        run: |
+          cargo install --debug cargo-depgraph
+
+      - name: Install svgcleaner
+        run: |
+          cargo install --debug svgcleaner
+
+      - name: Generate dependency graph
+        run: |
+          cargo depgraph                                \
+          | dot -Tsvg -Nfontname=monospace              \
+          | sed 's/stroke="transparent"/stroke="none"/' \
+          | svgcleaner --indent 0 --stdout -            \
+          > images/textwrap-${{ needs.setup.outputs.new-version }}.svg
+
+      - name: Commit dependency graph
+        run: |
+          git commit --all -m "Update dependency graph for version ${{ needs.setup.outputs.new-version }}"
+
       - name: Update changelog for version ${{ needs.setup.outputs.new-version }}
         id: changelog
         uses: actions/github-script@v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["text", "formatting", "wrap", "typesetting", "hyphenation"]
 categories = ["text-processing", "command-line-interface"]
 license = "MIT"
 edition = "2018"
-exclude = [".github/", ".gitignore", "benches/", "examples/", "fuzz/"]
+exclude = [".github/", ".gitignore", "benches/", "examples/", "fuzz/", "images/"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/images/textwrap-0.13.2.svg
+++ b/images/textwrap-0.13.2.svg
@@ -1,0 +1,17 @@
+<svg height="116pt" viewBox="0 0 262.29 116" width="262pt" xmlns="http://www.w3.org/2000/svg">
+<g transform="translate(4 112)">
+<path d="m-4 4v-116h262.29v116z" fill="#fff"/>
+<path d="m147.2-108h-83v36h83z" fill="none" stroke="#000"/>
+<text font-family="monospace" font-size="14" text-anchor="middle" x="105.7" y="-86.3">textwrap</text>
+<ellipse cx="37.7" cy="-18" fill="none" rx="37.89" ry="18" stroke="#000" stroke-dasharray="5 2"/>
+<text font-family="monospace" font-size="14" text-anchor="middle" x="37.7" y="-14.3">smawk</text>
+<g stroke="#000">
+<path d="m88.89-71.7c-8.69 8.95-19.41 19.99-28.8 29.64" fill="none" stroke-dasharray="1 5"/>
+<path d="m62.4-39.41-9.48 4.74 4.46-9.61z"/>
+<ellipse cx="173.7" cy="-18" fill="none" rx="80.69" ry="18" stroke-dasharray="5 2"/>
+</g>
+<text font-family="monospace" font-size="14" text-anchor="middle" x="173.7" y="-14.3">unicode-width</text>
+<path d="m122.51-71.7c8.31 8.56 18.49 19.04 27.58 28.4" fill="none" stroke="#000" stroke-dasharray="1 5"/>
+<path d="m152.62-45.72 4.46 9.62-9.48-4.74z" stroke="#000"/>
+</g>
+</svg>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,6 +118,11 @@
 //! Cargo features. This means you only pay for the features you
 //! actually use.
 //!
+//! The full dependency graph, where dashed lines indicate optional
+//! dependencies, is shown below:
+//!
+//! <img src="https://raw.githubusercontent.com/mgeisler/textwrap/master/images/textwrap-0.13.2.svg">
+//!
 //! ## Default Features
 //!
 //! These features are enabled by default:

--- a/tests/version-numbers.rs
+++ b/tests/version-numbers.rs
@@ -15,3 +15,8 @@ fn test_changelog() {
 fn test_html_root_url() {
     version_sync::assert_html_root_url_updated!("src/lib.rs");
 }
+
+#[test]
+fn test_dependency_graph() {
+    version_sync::assert_contains_regex!("src/lib.rs", "master/images/textwrap-{version}.svg");
+}


### PR DESCRIPTION
This used `cargo-depgraph` to generate a dependency graph which we convert to a SVG image. The image is committed to the repository under a versioned filename. This allows us to link to the correct image in the documentation.

The dependency graph is updated when new tags are pushed — this should ensure that the images are kept up to date. A new test has been added to ensure that we always refer to the correct version in the documentation.