### PR TITLE
Extend display_width to handle emojis when unicode-width is disabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ hyphenation = { version = "0.8", optional = true, features = ["embed_en-us"] }
 lipsum = "0.7"
 version-sync = "0.9"
 criterion = "0.3"
+unic-emoji-char = "0.9.0"
 
 [target.'cfg(unix)'.dev-dependencies]
 termion = "1.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,8 +124,9 @@
 //!
 //! * `unicode-width`: enables correct width computation of non-ASCII
 //!   characters via the [unicode-width] crate. Without this feature,
-//!   every [`char`] is 1 column wide. See the [`core::display_width`]
-//!   function for details.
+//!   every [`char`] is 1 column wide, except for emojis which are 2
+//!   columns wide. See the [`core::display_width`] function for
+//!   details.
 //!
 //!   This feature can be disabled if you only need to wrap ASCII
 //!   text, or if the functions in [`core`] are used directly with
@@ -1238,16 +1239,10 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "unicode-width")]
     fn break_words_wide_characters() {
+        // Even the poor man's version of `ch_width` counts these
+        // characters as wide.
         assert_eq!(wrap("Ｈｅｌｌｏ", 5), vec!["Ｈｅ", "ｌｌ", "ｏ"]);
-    }
-
-    #[test]
-    #[cfg(not(feature = "unicode-width"))]
-    fn break_words_wide_characters() {
-        // Each `char` takes up one column.
-        assert_eq!(wrap("Ｈｅｌｌｏ", 5), vec!["Ｈｅｌｌｏ"]);
     }
 
     #[test]


### PR DESCRIPTION
The unicode-width Cargo feature is used by default to measure the width of the characters. Without it, we used to fall back to a simple model where each character is has a width of one column.

However, this is wrong for emojis such as “😂”, which normally take up two columns when printed in a terminal. We now handle such characters as well — we simply assume that all characters above U+1100 is a double-width character.

This turns out to be correct for emojis, but it is wrong for many non-emoji characters. To handle those, the unicode-width feature should simply be enabled.