### PR TITLE
Forbid warnings when building in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUSTFLAGS: -D warnings
 
 jobs:
 


### PR DESCRIPTION
Together with a weekly CI run, this should ensure that we catch new warnings quickly when they appear on the nightly Rust channel.