### PR TITLE
Remove unused [badges] section from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,6 @@ exclude = [".github/", ".gitignore", "benches/", "examples/", "fuzz/", "images/"
 [package.metadata.docs.rs]
 all-features = true
 
-[badges]
-travis-ci = { repository = "mgeisler/textwrap" }
-appveyor = { repository = "mgeisler/textwrap" }
-codecov = { repository = "mgeisler/textwrap" }
-
 [[bench]]
 name = "linear"
 harness = false


### PR DESCRIPTION
The badges are no longer shown on crates.io and I don’t think they were ever shown on lib.rs. According to the documentation we should instead rely on the badges in the README.

  https://doc.rust-lang.org/cargo/reference/manifest.html#the-badges-section