### PR TITLE
Split termwidth docstring into header and body

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -548,9 +548,11 @@ impl<'a, S: WordSplitter> Options<'a, S> {
     }
 }
 
-/// Return the current terminal width. If the terminal width cannot be
-/// determined (typically because the standard output is not connected
-/// to a terminal), a default width of 80 characters will be used.
+/// Return the current terminal width.
+///
+/// If the terminal width cannot be determined (typically because the
+/// standard output is not connected to a terminal), a default width
+/// of 80 characters will be used.
 ///
 /// # Examples
 ///


### PR DESCRIPTION
The docstring was a single paragraph, which would show up in the function overview generated by `cargo doc`.