### PR TITLE
Add `WordSeparator` trait to allow customizing how words are found in a line of text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,29 @@
 This file lists the most important changes made in each release of
 `textwrap`.
 
+## Unreleased
+
+This is a major feature release which adds a new generic type
+parameter to the `Options` struct. This new parameter lets you specify
+how words are found in the text.
+
+Common usages of textwrap stays unchanged, but if you previously
+spelled out the full type for `Options`, you now need to take th extra
+type parameter into account. This means that
+
+```rust
+let options: Options<HyphenSplitter> = Options::new(80);
+```
+
+need to change to
+
+```rust
+let options: Options<AsciiSpace, HyphenSplitter> = Options::new(80);
+```
+
+You won’t see any chance if you call `wrap` directly with a width or
+with an `Options` constructed on the fly.
+
 ## Version 0.13.4 (2021-02-23)
 
 This release removes `println!` statements which was left behind in

--- a/examples/interactive.rs
+++ b/examples/interactive.rs
@@ -21,7 +21,8 @@ mod unix_only {
     use termion::{color, cursor, style};
     #[cfg(feature = "smawk")]
     use textwrap::core::WrapAlgorithm::{FirstFit, OptimalFit};
-    use textwrap::{wrap, HyphenSplitter, NoHyphenation, Options, WordSplitter};
+    use textwrap::{wrap, AsciiSpace, Options};
+    use textwrap::{HyphenSplitter, NoHyphenation, WordSplitter};
 
     #[cfg(feature = "hyphenation")]
     use hyphenation::{Language, Load, Standard};
@@ -56,7 +57,7 @@ mod unix_only {
 
     fn draw_text<'a>(
         text: &str,
-        options: &Options<'a>,
+        options: &Options<'a, AsciiSpace, Box<dyn WordSplitter>>,
         splitter_label: &str,
         stdout: &mut RawTerminal<io::Stdout>,
     ) -> Result<(), io::Error> {
@@ -256,7 +257,8 @@ mod unix_only {
         }
 
         let mut label = labels.pop().unwrap();
-        let mut options: Options = Options::new(35).splitter(Box::new(HyphenSplitter));
+        let mut options =
+            Options::new(35).splitter(Box::new(HyphenSplitter) as Box<dyn WordSplitter>);
         options.break_words = false;
         options.splitter = splitters.pop().unwrap();
 

--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -1,4 +1,4 @@
-use textwrap::{wrap, HyphenSplitter, Options};
+use textwrap::{wrap, HyphenSplitter, Options, WordSplitter};
 
 fn main() {
     let example = "Memory safety without garbage collection. \
@@ -6,7 +6,7 @@ fn main() {
                    Zero-cost abstractions.";
     let mut prev_lines = vec![];
 
-    let mut options: Options = Options::new(0).splitter(Box::new(HyphenSplitter));
+    let mut options = Options::new(0).splitter(Box::new(HyphenSplitter) as Box<dyn WordSplitter>);
     #[cfg(feature = "hyphenation")]
     {
         use hyphenation::Load;

--- a/examples/wasm/src/lib.rs
+++ b/examples/wasm/src/lib.rs
@@ -160,7 +160,7 @@ pub fn draw_wrapped_text(
 
     let mut lineno = 0;
     for line in text.split('\n') {
-        let words = core::find_words(line);
+        let words = options.word_separator.find_words(line);
         let split_words = core::split_words(words, &options);
 
         let canvas_words = split_words

--- a/src/splitting.rs
+++ b/src/splitting.rs
@@ -55,7 +55,7 @@ pub trait WordSplitter: WordSplitterClone + std::fmt::Debug {
 
 // The internal `WordSplitterClone` trait is allows us to implement
 // `Clone` for `Box<dyn WordSplitter>`. This in used in the
-// `From<&Options<'_, S>> for Options<'a, S>` implementation.
+// `From<&Options<'_, R, S>> for Options<'a, R, S>` implementation.
 pub trait WordSplitterClone {
     fn clone_box(&self) -> Box<dyn WordSplitter>;
 }

--- a/src/word_separator.rs
+++ b/src/word_separator.rs
@@ -1,0 +1,218 @@
+//! Line breaking functionality.
+
+use crate::core::Word;
+
+/// Describes where a line break can occur.
+///
+/// The simplest approach is say that a line can end after one or more
+/// ASCII spaces (`' '`). This works for Western languages without
+/// emojis.
+///
+/// The line breaks occur between words, please see the
+/// [`WordSplitter`](crate::WordSplitter) trait for options of how
+/// to handle hyphenation of individual words.
+///
+/// # Examples
+///
+/// ```
+/// use textwrap::{WordSeparator, AsciiSpace};
+/// use textwrap::core::Word;
+/// let words = AsciiSpace.find_words("Hello World!").collect::<Vec<_>>();
+/// assert_eq!(words, vec![Word::from("Hello "), Word::from("World!")]);
+/// ```
+pub trait WordSeparator: WordSeparatorClone + std::fmt::Debug {
+    // This trait should really return impl Iterator<Item = Word>, but
+    // this isn't possible until Rust supports higher-kinded types:
+    // https://github.com/rust-lang/rfcs/blob/master/text/1522-conservative-impl-trait.md
+    /// Find all words in `line`.
+    fn find_words<'a>(&self, line: &'a str) -> Box<dyn Iterator<Item = Word<'a>> + 'a>;
+}
+
+// The internal `WordSeparatorClone` trait is allows us to implement
+// `Clone` for `Box<dyn WordSeparator>`. This in used in the
+// `From<&Options<'_, R, S>> for Options<'a, R, S>` implementation.
+pub trait WordSeparatorClone {
+    fn clone_box(&self) -> Box<dyn WordSeparator>;
+}
+
+impl<T: WordSeparator + Clone + 'static> WordSeparatorClone for T {
+    fn clone_box(&self) -> Box<dyn WordSeparator> {
+        Box::new(self.clone())
+    }
+}
+
+impl Clone for Box<dyn WordSeparator> {
+    fn clone(&self) -> Box<dyn WordSeparator> {
+        use std::ops::Deref;
+        self.deref().clone_box()
+    }
+}
+
+impl WordSeparator for Box<dyn WordSeparator> {
+    fn find_words<'a>(&self, line: &'a str) -> Box<dyn Iterator<Item = Word<'a>> + 'a> {
+        use std::ops::Deref;
+        self.deref().find_words(line)
+    }
+}
+
+/// Find line breaks by regions of `' '` characters.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct AsciiSpace;
+
+/// Split `line` into words separated by regions of `' '` characters.
+///
+/// # Examples
+///
+/// ```
+/// use textwrap::core::Word;
+/// use textwrap::{AsciiSpace, WordSeparator};
+///
+/// let words = AsciiSpace.find_words("Hello   World!").collect::<Vec<_>>();
+/// assert_eq!(words, vec![Word::from("Hello   "),
+///                        Word::from("World!")]);
+/// ```
+impl WordSeparator for AsciiSpace {
+    fn find_words<'a>(&self, line: &'a str) -> Box<dyn Iterator<Item = Word<'a>> + 'a> {
+        let mut start = 0;
+        let mut in_whitespace = false;
+        let mut char_indices = line.char_indices();
+
+        Box::new(std::iter::from_fn(move || {
+            // for (idx, ch) in char_indices does not work, gives this
+            // error:
+            //
+            // > cannot move out of `char_indices`, a captured variable in
+            // > an `FnMut` closure
+            #[allow(clippy::while_let_on_iterator)]
+            while let Some((idx, ch)) = char_indices.next() {
+                if in_whitespace && ch != ' ' {
+                    let word = Word::from(&line[start..idx]);
+                    start = idx;
+                    in_whitespace = ch == ' ';
+                    return Some(word);
+                }
+
+                in_whitespace = ch == ' ';
+            }
+
+            if start < line.len() {
+                let word = Word::from(&line[start..]);
+                start = line.len();
+                return Some(word);
+            }
+
+            None
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Like assert_eq!, but the left expression is an iterator.
+    macro_rules! assert_iter_eq {
+        ($left:expr, $right:expr) => {
+            assert_eq!($left.collect::<Vec<_>>(), $right);
+        };
+    }
+
+    #[test]
+    fn ascii_space_empty() {
+        assert_iter_eq!(AsciiSpace.find_words(""), vec![]);
+    }
+
+    #[test]
+    fn ascii_space_single_word() {
+        assert_iter_eq!(AsciiSpace.find_words("foo"), vec![Word::from("foo")]);
+    }
+
+    #[test]
+    fn ascii_space_two_words() {
+        assert_iter_eq!(
+            AsciiSpace.find_words("foo bar"),
+            vec![Word::from("foo "), Word::from("bar")]
+        );
+    }
+
+    #[test]
+    fn ascii_space_multiple_words() {
+        assert_iter_eq!(
+            AsciiSpace.find_words("foo bar baz"),
+            vec![Word::from("foo "), Word::from("bar "), Word::from("baz")]
+        );
+    }
+
+    #[test]
+    fn ascii_space_only_whitespace() {
+        assert_iter_eq!(AsciiSpace.find_words("    "), vec![Word::from("    ")]);
+    }
+
+    #[test]
+    fn ascii_space_inter_word_whitespace() {
+        assert_iter_eq!(
+            AsciiSpace.find_words("foo   bar"),
+            vec![Word::from("foo   "), Word::from("bar")]
+        )
+    }
+
+    #[test]
+    fn ascii_space_trailing_whitespace() {
+        assert_iter_eq!(AsciiSpace.find_words("foo   "), vec![Word::from("foo   ")]);
+    }
+
+    #[test]
+    fn ascii_space_leading_whitespace() {
+        assert_iter_eq!(
+            AsciiSpace.find_words("   foo"),
+            vec![Word::from("   "), Word::from("foo")]
+        );
+    }
+
+    #[test]
+    fn ascii_space_multi_column_char() {
+        assert_iter_eq!(
+            AsciiSpace.find_words("\u{1f920}"), // cowboy emoji 🤠
+            vec![Word::from("\u{1f920}")]
+        );
+    }
+
+    #[test]
+    fn ascii_space_hyphens() {
+        assert_iter_eq!(
+            AsciiSpace.find_words("foo-bar"),
+            vec![Word::from("foo-bar")]
+        );
+        assert_iter_eq!(
+            AsciiSpace.find_words("foo- bar"),
+            vec![Word::from("foo- "), Word::from("bar")]
+        );
+        assert_iter_eq!(
+            AsciiSpace.find_words("foo - bar"),
+            vec![Word::from("foo "), Word::from("- "), Word::from("bar")]
+        );
+        assert_iter_eq!(
+            AsciiSpace.find_words("foo -bar"),
+            vec![Word::from("foo "), Word::from("-bar")]
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn ascii_space_colored_text() {
+        use termion::color::{Blue, Fg, Green, Reset};
+
+        let green_hello = format!("{}Hello{} ", Fg(Green), Fg(Reset));
+        let blue_world = format!("{}World!{}", Fg(Blue), Fg(Reset));
+        assert_iter_eq!(
+            AsciiSpace.find_words(&format!("{}{}", green_hello, blue_world)),
+            vec![Word::from(&green_hello), Word::from(&blue_world)]
+        );
+    }
+
+    #[test]
+    fn ascii_space_color_inside_word() {
+        let text = "foo\u{1b}[0m\u{1b}[32mbar\u{1b}[0mbaz";
+        assert_iter_eq!(AsciiSpace.find_words(&text), vec![Word::from(text)]);
+    }
+}

--- a/tests/traits.rs
+++ b/tests/traits.rs
@@ -1,9 +1,10 @@
-use textwrap::{NoHyphenation, Options};
+use textwrap::{AsciiSpace, HyphenSplitter, NoHyphenation, Options, WordSeparator, WordSplitter};
 
 /// Cleaned up type name.
 fn type_name<T: ?Sized>(_val: &T) -> String {
     std::any::type_name::<T>()
         .replace("alloc::boxed::Box", "Box")
+        .replace("textwrap::word_separator", "textwrap")
         .replace("textwrap::splitting", "textwrap")
 }
 
@@ -13,33 +14,44 @@ fn static_hyphensplitter() {
     let options = Options::new(10);
     assert_eq!(
         type_name(&options),
-        "textwrap::Options<textwrap::HyphenSplitter>"
+        "textwrap::Options<textwrap::AsciiSpace, textwrap::HyphenSplitter>"
     );
 
-    // Explicitly making both parameters inferred.
-    let options: Options<'_, _> = Options::new(10);
+    // Inferring part of the type.
+    let options: Options<_, HyphenSplitter> = Options::new(10);
     assert_eq!(
         type_name(&options),
-        "textwrap::Options<textwrap::HyphenSplitter>"
+        "textwrap::Options<textwrap::AsciiSpace, textwrap::HyphenSplitter>"
+    );
+
+    // Explicitly making all parameters inferred.
+    let options: Options<'_, _, _> = Options::new(10);
+    assert_eq!(
+        type_name(&options),
+        "textwrap::Options<textwrap::AsciiSpace, textwrap::HyphenSplitter>"
     );
 }
 
 #[test]
 fn box_static_nohyphenation() {
     // Inferred static type.
-    let options = Options::new(10).splitter(Box::new(NoHyphenation));
+    let options = Options::new(10)
+        .splitter(Box::new(NoHyphenation))
+        .word_separator(Box::new(AsciiSpace));
     assert_eq!(
         type_name(&options),
-        "textwrap::Options<Box<textwrap::NoHyphenation>>"
+        "textwrap::Options<Box<textwrap::AsciiSpace>, Box<textwrap::NoHyphenation>>"
     );
 }
 
 #[test]
 fn box_dyn_wordsplitter() {
     // Inferred dynamic type due to default type parameter.
-    let options: Options = Options::new(10).splitter(Box::new(NoHyphenation));
+    let options = Options::new(10)
+        .splitter(Box::new(NoHyphenation) as Box<dyn WordSplitter>)
+        .word_separator(Box::new(AsciiSpace) as Box<dyn WordSeparator>);
     assert_eq!(
         type_name(&options),
-        "textwrap::Options<Box<dyn textwrap::WordSplitter>>"
+        "textwrap::Options<Box<dyn textwrap::WordSeparator>, Box<dyn textwrap::WordSplitter>>"
     );
 }


### PR DESCRIPTION
The new trait is responsible for turning a line of text into an iterator of `Word`s. The first implementation is `AsciiSpace`, which
simply splits the input text on `' '`. This matches the current behavior.

The new trait shows up as an extra generic parameter on `Options`. This is quite invasive in the case of dynamic dispatch: when you could write

```rust
let options: Options = Options::with_splitter(80, NoHyphenation);
```

before to create a `Options<Box<dyn WordSplitter>>`, you now need to cast two types to trait objects to achive the same thing:

```rust
let mut options = Options::new(80)
    .splitter(Box::new(HyphenSplitter) as Box<dyn WordSplitter>)
    .word_separator(Box::new(AsciiSpace) as Box<dyn WordSeparator>);
```