### PR TITLE
Stop inlining `display_width`

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -176,7 +176,6 @@ fn ch_width(ch: char) -> usize {
 /// [Unicode equivalence]: https://en.wikipedia.org/wiki/Unicode_equivalence
 /// [CJK characters]: https://en.wikipedia.org/wiki/CJK_characters
 /// [emoji modifier sequences]: https://unicode.org/emoji/charts/full-emoji-modifiers.html
-#[inline]
 pub fn display_width(text: &str) -> usize {
     let mut chars = text.chars();
     let mut width = 0;


### PR DESCRIPTION
This removes the size of Textwrap drops from 16.3 KiB to 13.5 KiB as per `cargo bloat` on a simple “Hello World” program.

As far as I can measure, inlining `display_width` actually makes performance slightly worse. The benchmark results jump around a little, but we can plot them as a histogram. All numbers are microseconds for the `fill_optimal_fit_ascii/4800` benchmark.

With the `#[inline]` attribute:

    # Mean = 254.7
    237 .. 240 [  1 ]: ∎
    240 .. 243 [  1 ]: ∎
    243 .. 246 [  0 ]:
    246 .. 249 [  1 ]: ∎
    249 .. 252 [  9 ]: ∎∎∎∎∎∎∎∎∎
    252 .. 255 [  6 ]: ∎∎∎∎∎∎
    255 .. 258 [ 15 ]: ∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
    258 .. 261 [ 15 ]: ∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
    261 .. 264 [  1 ]: ∎
    264 .. 267 [  1 ]: ∎

Without the `#[inline]` attribute:

    # Mean = 251.8
    239 .. 241 [  1 ]: ∎
    241 .. 243 [  1 ]: ∎
    243 .. 245 [  4 ]: ∎∎∎∎
    245 .. 247 [  4 ]: ∎∎∎∎
    247 .. 249 [  2 ]: ∎∎
    249 .. 251 [  7 ]: ∎∎∎∎∎∎∎
    251 .. 253 [  9 ]: ∎∎∎∎∎∎∎∎∎
    253 .. 255 [  3 ]: ∎∎∎
    255 .. 257 [  7 ]: ∎∎∎∎∎∎∎
    257 .. 259 [ 12 ]: ∎∎∎∎∎∎∎∎∎∎∎∎

As can be seen, the mean drops by 3 microseconds.