### PR TITLE
Shorten benchmark warm-up time

### DIFF
--- a/benches/linear.rs
+++ b/benches/linear.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use criterion::BenchmarkId;
 use criterion::Criterion;
 use criterion::{criterion_group, criterion_main};
@@ -87,5 +89,9 @@ pub fn benchmark(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, benchmark);
+criterion_group!(
+    name = benches;
+    config = Criterion::default().warm_up_time(Duration::from_millis(500));
+    targets = benchmark
+);
 criterion_main!(benches);


### PR DESCRIPTION
By default, Criterion will run a warm-up loop for 3 seconds followed by the actual benchmark loop for 5 seconds. Since our benchmarks are CPU bound, it seems unnecessary to spend 37% of the time warming up.