### PR TITLE
Bump insecure indirect ssri dependency of Wasm demo

### DIFF
--- a/examples/wasm/www/package-lock.json
+++ b/examples/wasm/www/package-lock.json
@@ -5646,9 +5646,10 @@
             }
         },
         "node_modules/ssri": {
-            "version": "6.0.1",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
+            "integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "figgy-pudding": "^3.5.1"
             }
@@ -10737,7 +10738,9 @@
             }
         },
         "ssri": {
-            "version": "6.0.1",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
+            "integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
             "dev": true,
             "requires": {
                 "figgy-pudding": "^3.5.1"


### PR DESCRIPTION
GitHub informs me that this version is affected by a DOS attack: https://github.com/advisories/GHSA-vx3p-948g-6vhq.