### PR TITLE
Fix ignoring the `example/wasm/www/dist/` folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,8 @@ target/
 *.rej
 *.orig
 
-examples/wasm/dist/
 examples/wasm/pkg/
+examples/wasm/www/dist/
 examples/wasm/www/node_modules/
 
 fuzz/artifacts/


### PR DESCRIPTION
I added the wrong path in #343.