### PR TITLE
Trim trailing whitespace from `prefix` in `indent`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,12 +86,12 @@
 //! into a bullet list:
 //!
 //! ```
-//! let before = "
+//! let before = "\
 //! foo
 //! bar
 //! baz
 //! ";
-//! let after = "
+//! let after = "\
 //! * foo
 //! * bar
 //! * baz


### PR DESCRIPTION
Before, empty lines would get no prefix added. Now, empty lines have a trimmed prefix added.

This little trick makes `indent` much more useful: you can now indent with `"# "` without fearing creating trailing whitespace in the output due to the trailing whitespace in your prefix.

When you indent with a prefix of pure whitespace, such as `" "` or similar, you will see no difference. If you indent with a non-whitespace prefix, you will now see it added to every line of your input.