### PR TITLE
Preserve the `build-info.json` file on the `gh-pages` branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,6 +143,7 @@ jobs:
       - name: Add and remove changed files
         id: git-add
         run: |
+          git restore build-info.json
           git add --verbose --all
           if git diff --staged --quiet --exit-code; then
             echo "No changes found in textwrap-wasm-demo-app"


### PR DESCRIPTION
On `master`, we have an empty `build-info.json` file. When bundling
the Wasm demo, this file was included in the `dist/` directory. When
we later unpack this onto the `gh-pages` branch, we would end up with
a dirty working copy – even if nothing else had changed since the last
commit on that branch.

With this change, we eliminate this source of change by restoring the
`build-info.json` file after we unpack the bundle. This way we can
detect if something changed in the bundle itself.