### PR TITLE
Replace `core::WrapAlgorithm` enum with `WrapAlgorithm` trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,26 @@ This file lists the most important changes made in each release of
 
 ## Unreleased
 
-This is a major feature release which adds a new generic type
-parameter to the `Options` struct. This new parameter lets you specify
-how words are found in the text.
+This is a major feature release which adds new generic type parameters
+to the `Options` struct. These parameters lets you statically
+configure the wrapping algorithm and the word separator:
+
+* `wrap_algorithms::WrapAlgorithm`: this trait replaces the old
+  `core::WrapAlgorithm` enum. The enum variants are now two structs:
+  `wrap_algorithms::FirstFit` and `wrap_algorithms::OptimalFit`.
+
+* `WordSeparator`: this new trait lets you specify how words are
+  separated in the text. Until now, Textwrap would simply split on
+  spaces. While this works okay for Western languages, it fails to
+  take emojis and East-Asian languages into account.
+
+  The new `AsciiSpace` and `UnicodeBreakProperties` structs implement
+  the trait. The latter is available if the new optional
+  `unicode-linebreak` Cargo feature is enabled.
 
 Common usages of textwrap stays unchanged, but if you previously
-spelled out the full type for `Options`, you now need to take th extra
-type parameter into account. This means that
+spelled out the full type for `Options`, you now need to take the
+extra type parameters into account. This means that
 
 ```rust
 let options: Options<HyphenSplitter> = Options::new(80);
@@ -20,7 +33,7 @@ let options: Options<HyphenSplitter> = Options::new(80);
 need to change to
 
 ```rust
-let options: Options<AsciiSpace, HyphenSplitter> = Options::new(80);
+let options: Options<wrap_algorithms::FirstFit, AsciiSpace, HyphenSplitter> = Options::new(80);
 ```
 
 You won’t see any chance if you call `wrap` directly with a width or

--- a/benches/linear.rs
+++ b/benches/linear.rs
@@ -31,7 +31,7 @@ pub fn benchmark(c: &mut Criterion) {
             #[cfg(feature = "unicode-linebreak")]
             {
                 let options = textwrap::Options::new(LINE_LENGTH)
-                    .wrap_algorithm(textwrap::core::WrapAlgorithm::OptimalFit)
+                    .wrap_algorithm(textwrap::wrap_algorithms::OptimalFit)
                     .word_separator(textwrap::UnicodeBreakProperties);
                 group.bench_with_input(
                     BenchmarkId::new("fill_optimal_fit_unicode", length),
@@ -43,7 +43,7 @@ pub fn benchmark(c: &mut Criterion) {
             }
 
             let options = textwrap::Options::new(LINE_LENGTH)
-                .wrap_algorithm(textwrap::core::WrapAlgorithm::OptimalFit)
+                .wrap_algorithm(textwrap::wrap_algorithms::OptimalFit)
                 .word_separator(textwrap::AsciiSpace);
             group.bench_with_input(
                 BenchmarkId::new("fill_optimal_fit_ascii", length),
@@ -55,7 +55,7 @@ pub fn benchmark(c: &mut Criterion) {
         }
 
         let options = textwrap::Options::new(LINE_LENGTH)
-            .wrap_algorithm(textwrap::core::WrapAlgorithm::FirstFit)
+            .wrap_algorithm(textwrap::wrap_algorithms::FirstFit)
             .word_separator(textwrap::AsciiSpace);
         group.bench_with_input(
             BenchmarkId::new("fill_first_fit", length),

--- a/examples/wasm/src/lib.rs
+++ b/examples/wasm/src/lib.rs
@@ -1,7 +1,7 @@
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 
-use textwrap::{core, WordSeparator};
+use textwrap::{core, wrap_algorithms, WordSeparator};
 
 #[wasm_bindgen]
 extern "C" {
@@ -168,7 +168,7 @@ pub fn draw_wrapped_text(
             .collect::<Vec<_>>();
 
         let line_lengths = [width * PRECISION];
-        let wrapped_words = core::wrap_first_fit(&canvas_words, &line_lengths);
+        let wrapped_words = wrap_algorithms::wrap_first_fit(&canvas_words, &line_lengths);
 
         for words_in_line in wrapped_words {
             lineno += 1;

--- a/fuzz/fuzz_targets/fill_first_fit.rs
+++ b/fuzz/fuzz_targets/fill_first_fit.rs
@@ -1,9 +1,9 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
-use textwrap::core::WrapAlgorithm::FirstFit;
+use textwrap::wrap_algorithms;
 use textwrap::Options;
 
 fuzz_target!(|input: (String, usize)| {
-    let options = Options::new(input.1).wrap_algorithm(FirstFit);
+    let options = Options::new(input.1).wrap_algorithm(wrap_algorithms::FirstFit);
     let _ = textwrap::fill(&input.0, &options);
 });

--- a/fuzz/fuzz_targets/fill_optimal_fit.rs
+++ b/fuzz/fuzz_targets/fill_optimal_fit.rs
@@ -1,9 +1,9 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
-use textwrap::core::WrapAlgorithm::OptimalFit;
+use textwrap::wrap_algorithms;
 use textwrap::Options;
 
 fuzz_target!(|input: (String, usize)| {
-    let options = Options::new(input.1).wrap_algorithm(OptimalFit);
+    let options = Options::new(input.1).wrap_algorithm(wrap_algorithms::OptimalFit);
     let _ = textwrap::fill(&input.0, &options);
 });

--- a/src/core.rs
+++ b/src/core.rs
@@ -20,9 +20,11 @@
 //!    fit on a single line. This is implemented in [`break_words`].
 //!
 //! 4. Finally take your fragments and put them into lines. There are
-//!    two algorithms for this: [`wrap_optimal_fit`] and
-//!    [`wrap_first_fit`]. The former produces better line breaks, the
-//!    latter is faster.
+//!    two algorithms for this in the
+//!    [`wrap_algorithms`](crate::wrap_algorithms) module:
+//!    [`wrap_optimal_fit`](crate::wrap_algorithms::wrap_optimal_fit)
+//!    and [`wrap_first_fit`](crate::wrap_algorithms::wrap_first_fit).
+//!    The former produces better line breaks, the latter is faster.
 //!
 //! 5. Iterate through the slices returned by the wrapping functions
 //!    and construct your lines of output.
@@ -32,11 +34,6 @@
 //! improving it. We would love to hear from you!
 
 use crate::{Options, WordSplitter};
-
-#[cfg(feature = "smawk")]
-mod optimal_fit;
-#[cfg(feature = "smawk")]
-pub use optimal_fit::wrap_optimal_fit;
 
 /// The CSI or “Control Sequence Introducer” introduces an ANSI escape
 /// sequence. This is typically used for colored text and will be
@@ -353,9 +350,9 @@ impl Fragment for Word<'_> {
 ///     vec![Word::from("foo-bar")]
 /// );
 /// ```
-pub fn split_words<'a, I, R, S>(
+pub fn split_words<'a, I, A, R, S>(
     words: I,
-    options: &'a Options<'a, R, S>,
+    options: &'a Options<'a, A, R, S>,
 ) -> impl Iterator<Item = Word<'a>>
 where
     I: IntoIterator<Item = Word<'a>>,
@@ -411,207 +408,6 @@ where
         }
     }
     shortened_words
-}
-
-/// Wrapping algorithms.
-///
-/// After a text has been broken into [`Fragment`]s, the one now has
-/// to decide how to break the fragments into lines. The simplest
-/// algorithm for this is implemented by [`wrap_first_fit`]: it uses
-/// no look-ahead and simply adds fragments to the line as long as
-/// they fit. However, this can lead to poor line breaks if a large
-/// fragment almost-but-not-quite fits on a line. When that happens,
-/// the fragment is moved to the next line and it will leave behind a
-/// large gap. A more advanced algorithm, implemented by
-/// [`wrap_optimal_fit`], will take this into account. The optimal-fit
-/// algorithm considers all possible line breaks and will attempt to
-/// minimize the gaps left behind by overly short lines.
-///
-/// While both algorithms run in linear time, the first-fit algorithm
-/// is about 4 times faster than the optimal-fit algorithm.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub enum WrapAlgorithm {
-    /// Use an advanced algorithm which considers the entire paragraph
-    /// to find optimal line breaks. Implemented by
-    /// [`wrap_optimal_fit`].
-    ///
-    /// **Note:** Only available when the `smawk` Cargo feature is
-    /// enabled.
-    #[cfg(feature = "smawk")]
-    OptimalFit,
-    /// Use a fast and simple algorithm with no look-ahead to find
-    /// line breaks. Implemented by [`wrap_first_fit`].
-    FirstFit,
-}
-
-/// Wrap abstract fragments into lines with a first-fit algorithm.
-///
-/// The `line_widths` slice give the target line width for each line
-/// (the last slice element is repeated as necessary). This can be
-/// used to implement hanging indentation.
-///
-/// The fragments must already have been split into the desired
-/// widths, this function will not (and cannot) attempt to split them
-/// further when arranging them into lines.
-///
-/// # First-Fit Algorithm
-///
-/// This implements a simple “greedy” algorithm: accumulate fragments
-/// one by one and when a fragment no longer fits, start a new line.
-/// There is no look-ahead, we simply take first fit of the fragments
-/// we find.
-///
-/// While fast and predictable, this algorithm can produce poor line
-/// breaks when a long fragment is moved to a new line, leaving behind
-/// a large gap:
-///
-/// ```
-/// use textwrap::core::{wrap_first_fit, Word};
-/// use textwrap::{AsciiSpace, WordSeparator};
-///
-/// // Helper to convert wrapped lines to a Vec<String>.
-/// fn lines_to_strings(lines: Vec<&[Word<'_>]>) -> Vec<String> {
-///     lines.iter().map(|line| {
-///         line.iter().map(|word| &**word).collect::<Vec<_>>().join(" ")
-///     }).collect::<Vec<_>>()
-/// }
-///
-/// let text = "These few words will unfortunately not wrap nicely.";
-/// let words = AsciiSpace.find_words(text).collect::<Vec<_>>();
-/// assert_eq!(lines_to_strings(wrap_first_fit(&words, &[15])),
-///            vec!["These few words",
-///                 "will",  // <-- short line
-///                 "unfortunately",
-///                 "not wrap",
-///                 "nicely."]);
-///
-/// // We can avoid the short line if we look ahead:
-/// #[cfg(feature = "smawk")]
-/// assert_eq!(lines_to_strings(textwrap::core::wrap_optimal_fit(&words, &[15])),
-///            vec!["These few",
-///                 "words will",
-///                 "unfortunately",
-///                 "not wrap",
-///                 "nicely."]);
-/// ```
-///
-/// The [`wrap_optimal_fit`] function was used above to get better
-/// line breaks. It uses an advanced algorithm which tries to avoid
-/// short lines. This function is about 4 times faster than
-/// [`wrap_optimal_fit`].
-///
-/// # Examples
-///
-/// Imagine you're building a house site and you have a number of
-/// tasks you need to execute. Things like pour foundation, complete
-/// framing, install plumbing, electric cabling, install insulation.
-///
-/// The construction workers can only work during daytime, so they
-/// need to pack up everything at night. Because they need to secure
-/// their tools and move machines back to the garage, this process
-/// takes much more time than the time it would take them to simply
-/// switch to another task.
-///
-/// You would like to make a list of tasks to execute every day based
-/// on your estimates. You can model this with a program like this:
-///
-/// ```
-/// use textwrap::core::{wrap_first_fit, Fragment};
-///
-/// #[derive(Debug)]
-/// struct Task<'a> {
-///     name: &'a str,
-///     hours: usize,   // Time needed to complete task.
-///     sweep: usize,   // Time needed for a quick sweep after task during the day.
-///     cleanup: usize, // Time needed for full cleanup if day ends with this task.
-/// }
-///
-/// impl Fragment for Task<'_> {
-///     fn width(&self) -> usize { self.hours }
-///     fn whitespace_width(&self) -> usize { self.sweep }
-///     fn penalty_width(&self) -> usize { self.cleanup }
-/// }
-///
-/// // The morning tasks
-/// let tasks = vec![
-///     Task { name: "Foundation",  hours: 4, sweep: 2, cleanup: 3 },
-///     Task { name: "Framing",     hours: 3, sweep: 1, cleanup: 2 },
-///     Task { name: "Plumbing",    hours: 2, sweep: 2, cleanup: 2 },
-///     Task { name: "Electrical",  hours: 2, sweep: 1, cleanup: 2 },
-///     Task { name: "Insulation",  hours: 2, sweep: 1, cleanup: 2 },
-///     Task { name: "Drywall",     hours: 3, sweep: 1, cleanup: 2 },
-///     Task { name: "Floors",      hours: 3, sweep: 1, cleanup: 2 },
-///     Task { name: "Countertops", hours: 1, sweep: 1, cleanup: 2 },
-///     Task { name: "Bathrooms",   hours: 2, sweep: 1, cleanup: 2 },
-/// ];
-///
-/// // Fill tasks into days, taking `day_length` into account. The
-/// // output shows the hours worked per day along with the names of
-/// // the tasks for that day.
-/// fn assign_days<'a>(tasks: &[Task<'a>], day_length: usize) -> Vec<(usize, Vec<&'a str>)> {
-///     let mut days = Vec::new();
-///     // Assign tasks to days. The assignment is a vector of slices,
-///     // with a slice per day.
-///     let assigned_days: Vec<&[Task<'a>]> = wrap_first_fit(&tasks, &[day_length]);
-///     for day in assigned_days.iter() {
-///         let last = day.last().unwrap();
-///         let work_hours: usize = day.iter().map(|t| t.hours + t.sweep).sum();
-///         let names = day.iter().map(|t| t.name).collect::<Vec<_>>();
-///         days.push((work_hours - last.sweep + last.cleanup, names));
-///     }
-///     days
-/// }
-///
-/// // With a single crew working 8 hours a day:
-/// assert_eq!(
-///     assign_days(&tasks, 8),
-///     [
-///         (7, vec!["Foundation"]),
-///         (8, vec!["Framing", "Plumbing"]),
-///         (7, vec!["Electrical", "Insulation"]),
-///         (5, vec!["Drywall"]),
-///         (7, vec!["Floors", "Countertops"]),
-///         (4, vec!["Bathrooms"]),
-///     ]
-/// );
-///
-/// // With two crews working in shifts, 16 hours a day:
-/// assert_eq!(
-///     assign_days(&tasks, 16),
-///     [
-///         (14, vec!["Foundation", "Framing", "Plumbing"]),
-///         (15, vec!["Electrical", "Insulation", "Drywall", "Floors"]),
-///         (6, vec!["Countertops", "Bathrooms"]),
-///     ]
-/// );
-/// ```
-///
-/// Apologies to anyone who actually knows how to build a house and
-/// knows how long each step takes :-)
-pub fn wrap_first_fit<'a, 'b, T: Fragment>(
-    fragments: &'a [T],
-    line_widths: &'b [usize],
-) -> Vec<&'a [T]> {
-    // The final line width is used for all remaining lines.
-    let default_line_width = line_widths.last().copied().unwrap_or(0);
-    let mut lines = Vec::new();
-    let mut start = 0;
-    let mut width = 0;
-
-    for (idx, fragment) in fragments.iter().enumerate() {
-        let line_width = line_widths
-            .get(lines.len())
-            .copied()
-            .unwrap_or(default_line_width);
-        if width + fragment.width() + fragment.penalty_width() > line_width && idx > start {
-            lines.push(&fragments[start..idx]);
-            start = idx;
-            width = 0;
-        }
-        width += fragment.width() + fragment.whitespace_width();
-    }
-    lines.push(&fragments[start..]);
-    lines
 }
 
 #[cfg(test)]

--- a/src/splitting.rs
+++ b/src/splitting.rs
@@ -55,7 +55,8 @@ pub trait WordSplitter: WordSplitterClone + std::fmt::Debug {
 
 // The internal `WordSplitterClone` trait is allows us to implement
 // `Clone` for `Box<dyn WordSplitter>`. This in used in the
-// `From<&Options<'_, R, S>> for Options<'a, R, S>` implementation.
+// `From<&Options<'_, A, R, S>> for Options<'a, A, R, S>`
+// implementation.
 pub trait WordSplitterClone {
     fn clone_box(&self) -> Box<dyn WordSplitter>;
 }

--- a/src/word_separator.rs
+++ b/src/word_separator.rs
@@ -33,7 +33,8 @@ pub trait WordSeparator: WordSeparatorClone + std::fmt::Debug {
 
 // The internal `WordSeparatorClone` trait is allows us to implement
 // `Clone` for `Box<dyn WordSeparator>`. This in used in the
-// `From<&Options<'_, R, S>> for Options<'a, R, S>` implementation.
+// `From<&Options<'_, A, R, S>> for Options<'a, A, R, S>`
+// implementation.
 pub trait WordSeparatorClone {
     fn clone_box(&self) -> Box<dyn WordSeparator>;
 }

--- a/src/wrap_algorithms.rs
+++ b/src/wrap_algorithms.rs
@@ -1,0 +1,257 @@
+//! Word wrapping algorithms.
+//!
+//! After a text has been broken into words (or [`Fragment`]s), one
+//! now has to decide how to break the fragments into lines. The
+//! simplest algorithm for this is implemented by [`wrap_first_fit`]:
+//! it uses no look-ahead and simply adds fragments to the line as
+//! long as they fit. However, this can lead to poor line breaks if a
+//! large fragment almost-but-not-quite fits on a line. When that
+//! happens, the fragment is moved to the next line and it will leave
+//! behind a large gap. A more advanced algorithm, implemented by
+//! [`wrap_optimal_fit`], will take this into account. The optimal-fit
+//! algorithm considers all possible line breaks and will attempt to
+//! minimize the gaps left behind by overly short lines.
+//!
+//! While both algorithms run in linear time, the first-fit algorithm
+//! is about 4 times faster than the optimal-fit algorithm.
+
+#[cfg(feature = "smawk")]
+mod optimal_fit;
+#[cfg(feature = "smawk")]
+pub use optimal_fit::{wrap_optimal_fit, OptimalFit};
+
+use crate::core::{Fragment, Word};
+
+/// Describes how to wrap words into lines.
+///
+/// The simplest approach is to wrap words one word at a time. This is
+/// implemented by [`FirstFit`]. If the `smawk` Cargo feature is
+/// enabled, a more complex algorithm is available, implemented by
+/// [`OptimalFit`], which will look at an entire paragraph at a time
+/// in order to find optimal line breaks.
+pub trait WrapAlgorithm: WrapAlgorithmClone + std::fmt::Debug {
+    /// Wrap words according to line widths.
+    ///
+    /// The `line_widths` slice gives the target line width for each
+    /// line (the last slice element is repeated as necessary). This
+    /// can be used to implement hanging indentation.
+    ///
+    /// Please see the implementors of the trait for examples.
+    fn wrap<'a, 'b>(&self, words: &'b [Word<'a>], line_widths: &'b [usize]) -> Vec<&'b [Word<'a>]>;
+}
+
+// The internal `WrapAlgorithmClone` trait is allows us to implement
+// `Clone` for `Box<dyn WrapAlgorithm>`. This in used in the
+// `From<&Options<'_, A, R, S>> for Options<'a, A, R, S>`
+// implementation.
+#[doc(hidden)]
+pub trait WrapAlgorithmClone {
+    fn clone_box(&self) -> Box<dyn WrapAlgorithm>;
+}
+
+impl<T: WrapAlgorithm + Clone + 'static> WrapAlgorithmClone for T {
+    fn clone_box(&self) -> Box<dyn WrapAlgorithm> {
+        Box::new(self.clone())
+    }
+}
+
+impl Clone for Box<dyn WrapAlgorithm> {
+    fn clone(&self) -> Box<dyn WrapAlgorithm> {
+        use std::ops::Deref;
+        self.deref().clone_box()
+    }
+}
+
+impl WrapAlgorithm for Box<dyn WrapAlgorithm> {
+    fn wrap<'a, 'b>(&self, words: &'b [Word<'a>], line_widths: &'b [usize]) -> Vec<&'b [Word<'a>]> {
+        use std::ops::Deref;
+        self.deref().wrap(words, line_widths)
+    }
+}
+
+/// Wrap words using a fast and simple algorithm.
+///
+/// This algorithm uses no look-ahead when finding line breaks.
+/// Implemented by [`wrap_first_fit`], please see that function for
+/// details and examples.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct FirstFit;
+
+impl WrapAlgorithm for FirstFit {
+    #[inline]
+    fn wrap<'a, 'b>(&self, words: &'b [Word<'a>], line_widths: &'b [usize]) -> Vec<&'b [Word<'a>]> {
+        wrap_first_fit(words, line_widths)
+    }
+}
+
+/// Wrap abstract fragments into lines with a first-fit algorithm.
+///
+/// The `line_widths` slice gives the target line width for each line
+/// (the last slice element is repeated as necessary). This can be
+/// used to implement hanging indentation.
+///
+/// The fragments must already have been split into the desired
+/// widths, this function will not (and cannot) attempt to split them
+/// further when arranging them into lines.
+///
+/// # First-Fit Algorithm
+///
+/// This implements a simple “greedy” algorithm: accumulate fragments
+/// one by one and when a fragment no longer fits, start a new line.
+/// There is no look-ahead, we simply take first fit of the fragments
+/// we find.
+///
+/// While fast and predictable, this algorithm can produce poor line
+/// breaks when a long fragment is moved to a new line, leaving behind
+/// a large gap:
+///
+/// ```
+/// use textwrap::core::Word;
+/// use textwrap::wrap_algorithms;
+/// use textwrap::{AsciiSpace, WordSeparator};
+///
+/// // Helper to convert wrapped lines to a Vec<String>.
+/// fn lines_to_strings(lines: Vec<&[Word<'_>]>) -> Vec<String> {
+///     lines.iter().map(|line| {
+///         line.iter().map(|word| &**word).collect::<Vec<_>>().join(" ")
+///     }).collect::<Vec<_>>()
+/// }
+///
+/// let text = "These few words will unfortunately not wrap nicely.";
+/// let words = AsciiSpace.find_words(text).collect::<Vec<_>>();
+/// assert_eq!(lines_to_strings(wrap_algorithms::wrap_first_fit(&words, &[15])),
+///            vec!["These few words",
+///                 "will",  // <-- short line
+///                 "unfortunately",
+///                 "not wrap",
+///                 "nicely."]);
+///
+/// // We can avoid the short line if we look ahead:
+/// #[cfg(feature = "smawk")]
+/// assert_eq!(lines_to_strings(wrap_algorithms::wrap_optimal_fit(&words, &[15])),
+///            vec!["These few",
+///                 "words will",
+///                 "unfortunately",
+///                 "not wrap",
+///                 "nicely."]);
+/// ```
+///
+/// The [`wrap_optimal_fit`] function was used above to get better
+/// line breaks. It uses an advanced algorithm which tries to avoid
+/// short lines. This function is about 4 times faster than
+/// [`wrap_optimal_fit`].
+///
+/// # Examples
+///
+/// Imagine you're building a house site and you have a number of
+/// tasks you need to execute. Things like pour foundation, complete
+/// framing, install plumbing, electric cabling, install insulation.
+///
+/// The construction workers can only work during daytime, so they
+/// need to pack up everything at night. Because they need to secure
+/// their tools and move machines back to the garage, this process
+/// takes much more time than the time it would take them to simply
+/// switch to another task.
+///
+/// You would like to make a list of tasks to execute every day based
+/// on your estimates. You can model this with a program like this:
+///
+/// ```
+/// use textwrap::wrap_algorithms::wrap_first_fit;
+/// use textwrap::core::{Fragment, Word};
+///
+/// #[derive(Debug)]
+/// struct Task<'a> {
+///     name: &'a str,
+///     hours: usize,   // Time needed to complete task.
+///     sweep: usize,   // Time needed for a quick sweep after task during the day.
+///     cleanup: usize, // Time needed for full cleanup if day ends with this task.
+/// }
+///
+/// impl Fragment for Task<'_> {
+///     fn width(&self) -> usize { self.hours }
+///     fn whitespace_width(&self) -> usize { self.sweep }
+///     fn penalty_width(&self) -> usize { self.cleanup }
+/// }
+///
+/// // The morning tasks
+/// let tasks = vec![
+///     Task { name: "Foundation",  hours: 4, sweep: 2, cleanup: 3 },
+///     Task { name: "Framing",     hours: 3, sweep: 1, cleanup: 2 },
+///     Task { name: "Plumbing",    hours: 2, sweep: 2, cleanup: 2 },
+///     Task { name: "Electrical",  hours: 2, sweep: 1, cleanup: 2 },
+///     Task { name: "Insulation",  hours: 2, sweep: 1, cleanup: 2 },
+///     Task { name: "Drywall",     hours: 3, sweep: 1, cleanup: 2 },
+///     Task { name: "Floors",      hours: 3, sweep: 1, cleanup: 2 },
+///     Task { name: "Countertops", hours: 1, sweep: 1, cleanup: 2 },
+///     Task { name: "Bathrooms",   hours: 2, sweep: 1, cleanup: 2 },
+/// ];
+///
+/// // Fill tasks into days, taking `day_length` into account. The
+/// // output shows the hours worked per day along with the names of
+/// // the tasks for that day.
+/// fn assign_days<'a>(tasks: &[Task<'a>], day_length: usize) -> Vec<(usize, Vec<&'a str>)> {
+///     let mut days = Vec::new();
+///     // Assign tasks to days. The assignment is a vector of slices,
+///     // with a slice per day.
+///     let assigned_days: Vec<&[Task<'a>]> = wrap_first_fit(&tasks, &[day_length]);
+///     for day in assigned_days.iter() {
+///         let last = day.last().unwrap();
+///         let work_hours: usize = day.iter().map(|t| t.hours + t.sweep).sum();
+///         let names = day.iter().map(|t| t.name).collect::<Vec<_>>();
+///         days.push((work_hours - last.sweep + last.cleanup, names));
+///     }
+///     days
+/// }
+///
+/// // With a single crew working 8 hours a day:
+/// assert_eq!(
+///     assign_days(&tasks, 8),
+///     [
+///         (7, vec!["Foundation"]),
+///         (8, vec!["Framing", "Plumbing"]),
+///         (7, vec!["Electrical", "Insulation"]),
+///         (5, vec!["Drywall"]),
+///         (7, vec!["Floors", "Countertops"]),
+///         (4, vec!["Bathrooms"]),
+///     ]
+/// );
+///
+/// // With two crews working in shifts, 16 hours a day:
+/// assert_eq!(
+///     assign_days(&tasks, 16),
+///     [
+///         (14, vec!["Foundation", "Framing", "Plumbing"]),
+///         (15, vec!["Electrical", "Insulation", "Drywall", "Floors"]),
+///         (6, vec!["Countertops", "Bathrooms"]),
+///     ]
+/// );
+/// ```
+///
+/// Apologies to anyone who actually knows how to build a house and
+/// knows how long each step takes :-)
+pub fn wrap_first_fit<'a, 'b, T: Fragment>(
+    fragments: &'a [T],
+    line_widths: &'b [usize],
+) -> Vec<&'a [T]> {
+    // The final line width is used for all remaining lines.
+    let default_line_width = line_widths.last().copied().unwrap_or(0);
+    let mut lines = Vec::new();
+    let mut start = 0;
+    let mut width = 0;
+
+    for (idx, fragment) in fragments.iter().enumerate() {
+        let line_width = line_widths
+            .get(lines.len())
+            .copied()
+            .unwrap_or(default_line_width);
+        if width + fragment.width() + fragment.penalty_width() > line_width && idx > start {
+            lines.push(&fragments[start..idx]);
+            start = idx;
+            width = 0;
+        }
+        width += fragment.width() + fragment.whitespace_width();
+    }
+    lines.push(&fragments[start..]);
+    lines
+}

--- a/src/wrap_algorithms/optimal_fit.rs
+++ b/src/wrap_algorithms/optimal_fit.rs
@@ -1,5 +1,25 @@
-use crate::core::Fragment;
 use std::cell::RefCell;
+
+use crate::core::{Fragment, Word};
+use crate::wrap_algorithms::WrapAlgorithm;
+
+/// Wrap words using an advanced algorithm with look-ahead.
+///
+/// This wrapping algorithm considers the entire paragraph to find
+/// optimal line breaks. Implemented by [`wrap_optimal_fit`], please
+/// see that function for details and examples.
+///
+/// **Note:** Only available when the `smawk` Cargo feature is
+/// enabled.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct OptimalFit;
+
+impl WrapAlgorithm for OptimalFit {
+    #[inline]
+    fn wrap<'a, 'b>(&self, words: &'b [Word<'a>], line_widths: &'b [usize]) -> Vec<&'b [Word<'a>]> {
+        wrap_optimal_fit(words, line_widths)
+    }
+}
 
 /// Cache for line numbers. This is necessary to avoid a O(n**2)
 /// behavior when computing line numbers in [`wrap_optimal_fit`].
@@ -39,7 +59,8 @@ const NLINE_PENALTY: i32 = 1000;
 /// overflow the line by 1 character in extreme cases:
 ///
 /// ```
-/// use textwrap::core::{wrap_optimal_fit, Word};
+/// use textwrap::wrap_algorithms::wrap_optimal_fit;
+/// use textwrap::core::Word;
 ///
 /// let short = "foo ";
 /// let long = "x".repeat(50);
@@ -81,7 +102,7 @@ const HYPHEN_PENALTY: i32 = 25;
 
 /// Wrap abstract fragments into lines with an optimal-fit algorithm.
 ///
-/// The `line_widths` slice give the target line width for each line
+/// The `line_widths` slice gives the target line width for each line
 /// (the last slice element is repeated as necessary). This can be
 /// used to implement hanging indentation.
 ///

--- a/tests/traits.rs
+++ b/tests/traits.rs
@@ -1,4 +1,7 @@
-use textwrap::{AsciiSpace, NoHyphenation, Options, WordSeparator, WordSplitter};
+use textwrap::wrap_algorithms::{FirstFit, WrapAlgorithm};
+use textwrap::Options;
+use textwrap::{AsciiSpace, WordSeparator};
+use textwrap::{NoHyphenation, WordSplitter};
 
 /// Cleaned up type name.
 fn type_name<T: ?Sized>(_val: &T) -> String {
@@ -9,27 +12,43 @@ fn type_name<T: ?Sized>(_val: &T) -> String {
 }
 
 #[test]
+#[cfg(not(feature = "smawk"))]
 #[cfg(not(feature = "unicode-linebreak"))]
 fn static_hyphensplitter() {
     // Inferring the full type.
     let options = Options::new(10);
     assert_eq!(
         type_name(&options),
-        "textwrap::Options<textwrap::AsciiSpace, textwrap::HyphenSplitter>"
+        format!(
+            "textwrap::Options<{}, {}, {}>",
+            "textwrap::wrap_algorithms::FirstFit",
+            "textwrap::AsciiSpace",
+            "textwrap::HyphenSplitter"
+        )
     );
 
     // Inferring part of the type.
-    let options: Options<_, textwrap::HyphenSplitter> = Options::new(10);
+    let options: Options<_, _, textwrap::HyphenSplitter> = Options::new(10);
     assert_eq!(
         type_name(&options),
-        "textwrap::Options<textwrap::AsciiSpace, textwrap::HyphenSplitter>"
+        format!(
+            "textwrap::Options<{}, {}, {}>",
+            "textwrap::wrap_algorithms::FirstFit",
+            "textwrap::AsciiSpace",
+            "textwrap::HyphenSplitter"
+        )
     );
 
     // Explicitly making all parameters inferred.
-    let options: Options<'_, _, _> = Options::new(10);
+    let options: Options<_, _, _> = Options::new(10);
     assert_eq!(
         type_name(&options),
-        "textwrap::Options<textwrap::AsciiSpace, textwrap::HyphenSplitter>"
+        format!(
+            "textwrap::Options<{}, {}, {}>",
+            "textwrap::wrap_algorithms::FirstFit",
+            "textwrap::AsciiSpace",
+            "textwrap::HyphenSplitter"
+        )
     );
 }
 
@@ -37,11 +56,17 @@ fn static_hyphensplitter() {
 fn box_static_nohyphenation() {
     // Inferred static type.
     let options = Options::new(10)
+        .wrap_algorithm(Box::new(FirstFit))
         .splitter(Box::new(NoHyphenation))
         .word_separator(Box::new(AsciiSpace));
     assert_eq!(
         type_name(&options),
-        "textwrap::Options<Box<textwrap::AsciiSpace>, Box<textwrap::NoHyphenation>>"
+        format!(
+            "textwrap::Options<{}, {}, {}>",
+            "Box<textwrap::wrap_algorithms::FirstFit>",
+            "Box<textwrap::AsciiSpace>",
+            "Box<textwrap::NoHyphenation>"
+        )
     );
 }
 
@@ -49,10 +74,16 @@ fn box_static_nohyphenation() {
 fn box_dyn_wordsplitter() {
     // Inferred dynamic type due to default type parameter.
     let options = Options::new(10)
+        .wrap_algorithm(Box::new(FirstFit) as Box<dyn WrapAlgorithm>)
         .splitter(Box::new(NoHyphenation) as Box<dyn WordSplitter>)
         .word_separator(Box::new(AsciiSpace) as Box<dyn WordSeparator>);
     assert_eq!(
         type_name(&options),
-        "textwrap::Options<Box<dyn textwrap::WordSeparator>, Box<dyn textwrap::WordSplitter>>"
+        format!(
+            "textwrap::Options<{}, {}, {}>",
+            "Box<dyn textwrap::wrap_algorithms::WrapAlgorithm>",
+            "Box<dyn textwrap::WordSeparator>",
+            "Box<dyn textwrap::WordSplitter>"
+        )
     );
 }


### PR DESCRIPTION
This introduces a `textwrap::wrap_algorithms` module where the `wrap_first_fit` and `wrap_optimal_fit` functions now live.

A new `WrapAlgorithm` trait replaces the old enum. This allows for arbitrary wrapping algorithms to be plugged into the library. We should also be able to change the return type from `Vec<&[Word]>` to `Iterator<Item = Word>` and thus implement streaming wrapping for the first-fit in the future.

Fixes #325.