### PR TITLE
Switch wrapping functions to use a slice for `line_widths`

### DIFF
--- a/examples/wasm/src/lib.rs
+++ b/examples/wasm/src/lib.rs
@@ -167,8 +167,8 @@ pub fn draw_wrapped_text(
             .map(|word| CanvasWord::from(ctx, word))
             .collect::<Vec<_>>();
 
-        let line_lengths = |_| width * PRECISION;
-        let wrapped_words = core::wrap_first_fit(&canvas_words, line_lengths);
+        let line_lengths = [width * PRECISION];
+        let wrapped_words = core::wrap_first_fit(&canvas_words, &line_lengths);
 
         for words_in_line in wrapped_words {
             lineno += 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1053,12 +1053,11 @@ where
             split_words.collect::<Vec<_>>()
         };
 
-        #[rustfmt::skip]
-        let line_lengths = |i| if i == 0 { initial_width } else { subsequent_width };
+        let line_widths = [initial_width, subsequent_width];
         let wrapped_words = match options.wrap_algorithm {
             #[cfg(feature = "smawk")]
-            core::WrapAlgorithm::OptimalFit => core::wrap_optimal_fit(&broken_words, line_lengths),
-            core::WrapAlgorithm::FirstFit => core::wrap_first_fit(&broken_words, line_lengths),
+            core::WrapAlgorithm::OptimalFit => core::wrap_optimal_fit(&broken_words, &line_widths),
+            core::WrapAlgorithm::FirstFit => core::wrap_first_fit(&broken_words, &line_widths),
         };
 
         let mut idx = 0;
@@ -1282,7 +1281,7 @@ pub fn fill_inplace(text: &mut String, width: usize) {
     let mut offset = 0;
     for line in text.split('\n') {
         let words = AsciiSpace.find_words(line).collect::<Vec<_>>();
-        let wrapped_words = core::wrap_first_fit(&words, |_| width);
+        let wrapped_words = core::wrap_first_fit(&words, &[width]);
 
         let mut line_offset = offset;
         for words in &wrapped_words[..wrapped_words.len() - 1] {


### PR DESCRIPTION
I plan to introduce a trait for the wrap algorithms (#325) and this aligns better with such a trait. The reason is that a trait method cannot have generic parameters, such as a `F: Fn(usize) -> usize` parameter.