### PR TITLE
Fix Wasm demo after #361

### DIFF
--- a/examples/wasm/src/lib.rs
+++ b/examples/wasm/src/lib.rs
@@ -161,7 +161,7 @@ pub fn draw_wrapped_text(
     let mut lineno = 0;
     for line in text.split('\n') {
         let words = options.word_separator.find_words(line);
-        let split_words = core::split_words(words, &options);
+        let split_words = core::split_words(words, &options.splitter);
 
         let canvas_words = split_words
             .map(|word| CanvasWord::from(ctx, word))


### PR DESCRIPTION
I accidentally broke the demo in #361 because the “Build Wasm demo” GitHub action wasn’t yet a required check (it’s now required).