### PR TITLE
Add many more options to Wasm demo

### DIFF
--- a/examples/wasm/www/index.html
+++ b/examples/wasm/www/index.html
@@ -30,6 +30,11 @@
        bottom: 0;
        border-top: thin solid grey;
      }
+
+     div.option {
+       display: inline-block;
+       padding-right: 1em;
+     }
     </style>
   </head>
   <body>
@@ -39,14 +44,49 @@
 
 You can test the word-wrapping behavior by editing the text 😍✨</textarea>
 
-    <p>Font family:
-      <select id="font-family">
-        <option value="monospace">Monospace</option>
-        <option value="serif">Serif</option>
-        <option value="sans-serif">Sans-serif</option>
-      </select>.
-      Line width: <input type="number" id="line-width-text" min="0"> px.
-    </p>
+    <div>
+      <div class="option">
+        <label for="font-family">Font family:</label>
+        <select id="font-family">
+          <option value="monospace">Monospace</option>
+          <option value="serif">Serif</option>
+          <option value="sans-serif">Sans-serif</option>
+        </select>
+      </div>
+
+      <div class="option">
+        <label for="line-width-text">Line width:</label>
+        <input type="number" id="line-width-text" min="0"> px.
+      </div>
+
+      <div class="option">
+        <label for="word-separator">Word separator:</label>
+        <select id="word-separator">
+          <option value="UnicodeBreakProperties">Unicode breaks</option>
+          <option value="AsciiSpace">ASCII space</option>
+        </select>
+      </div>
+
+      <div class="option">
+        <label for="word-splitter">Word splitter:</label>
+        <select id="word-splitter">
+          <option value="HyphenSplitter">Hyphens</option>
+          <option value="NoHyphenation">No hyphenation</option>
+        </select>
+      </div>
+
+      <div class="option">
+        <label for="wrap-algorithm">Wrap algorithm:</label>
+        <select id="wrap-algorithm">
+          <!--
+               The optimal-fit algorithm does not work well for proportional
+               fonts, see https://github.com/mgeisler/textwrap/issues/326.
+               <option value="OptimalFit">Optimal-fit</option>
+          -->
+          <option value="FirstFit">First-fit</option>
+        </select>
+      </div>
+    </div>
 
     <div>
       <input type="range" id="line-width" min="0" max="300" value="250">

--- a/examples/wasm/www/index.js
+++ b/examples/wasm/www/index.js
@@ -1,4 +1,4 @@
-import { draw_wrapped_text } from "textwrap-wasm-demo";
+import { draw_wrapped_text, WasmOptions } from "textwrap-wasm-demo";
 
 fetch("build-info.json").then(response => response.json()).then(buildInfo => {
     if (buildInfo.date && buildInfo.commit) {
@@ -20,12 +20,19 @@ function redraw(event) {
     ctx.font = `20px ${fontFamily}`;
 
     let text = document.getElementById("text").value;
-    let lineWidth = document.getElementById("line-width");
-    draw_wrapped_text(ctx, text, lineWidth.valueAsNumber);
+    let lineWidth = document.getElementById("line-width").valueAsNumber;
+    let wordSeparator = document.getElementById("word-separator").value;
+    let wordSplitter = document.getElementById("word-splitter").value;
+    let wrapAlgorithm = document.getElementById("wrap-algorithm").value;
+    let options = new WasmOptions(lineWidth, wordSeparator, wordSplitter, wrapAlgorithm);
+    draw_wrapped_text(ctx, options, text);
 }
 
 document.getElementById("text").addEventListener("input", redraw);
 document.getElementById("font-family").addEventListener("input", redraw);
+document.getElementById("word-separator").addEventListener("input", redraw);
+document.getElementById("word-splitter").addEventListener("input", redraw);
+document.getElementById("wrap-algorithm").addEventListener("input", redraw);
 
 document.getElementById("line-width").addEventListener("input", (event) => {
     let lineWidthText = document.getElementById("line-width-text");


### PR DESCRIPTION
This makes the `WordSeparator` and `WordSplitter` and `WrapAlgorithm` configurable via drop-downs on the page. The `WrapAlgorithm` is limited to `FirstFit` at the moment since `OptimalFit` doesn’t play nice with the huge line widths we see when we measure things in px instead of in columns.

Fixes #321.
Fixes #322.