### PR TITLE
Add option for setting `break_words` in Wasm demo

### DIFF
--- a/examples/wasm/Cargo.lock
+++ b/examples/wasm/Cargo.lock
@@ -143,6 +143,7 @@ dependencies = [
  "console_error_panic_hook",
  "js-sys",
  "textwrap",
+ "unicode-segmentation",
  "wasm-bindgen",
  "wasm-bindgen-test",
  "web-sys",
@@ -156,6 +157,12 @@ checksum = "05a31f45d18a3213b918019f78fe6a73a14ab896807f0aaf5622aa0684749455"
 dependencies = [
  "regex",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
 
 [[package]]
 name = "unicode-width"

--- a/examples/wasm/Cargo.toml
+++ b/examples/wasm/Cargo.toml
@@ -18,6 +18,7 @@ console_error_panic_hook = "0.1"
 js-sys = "0.3"
 wasm-bindgen = "0.2"
 web-sys = { version = "0.3", features = ["CanvasRenderingContext2d", "TextMetrics"] }
+unicode-segmentation = "1.7"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/examples/wasm/www/index.html
+++ b/examples/wasm/www/index.html
@@ -60,6 +60,11 @@ You can test the word-wrapping behavior by editing the text 😍✨</textarea>
       </div>
 
       <div class="option">
+        <label for="break-words">Break long words:</label>
+        <input id="break-words" type="checkbox" checked>
+      </div>
+
+      <div class="option">
         <label for="word-separator">Word separator:</label>
         <select id="word-separator">
           <option value="UnicodeBreakProperties">Unicode breaks</option>

--- a/examples/wasm/www/index.js
+++ b/examples/wasm/www/index.js
@@ -21,15 +21,17 @@ function redraw(event) {
 
     let text = document.getElementById("text").value;
     let lineWidth = document.getElementById("line-width").valueAsNumber;
+    let breakWords = document.getElementById("break-words").checked;
     let wordSeparator = document.getElementById("word-separator").value;
     let wordSplitter = document.getElementById("word-splitter").value;
     let wrapAlgorithm = document.getElementById("wrap-algorithm").value;
-    let options = new WasmOptions(lineWidth, wordSeparator, wordSplitter, wrapAlgorithm);
+    let options = new WasmOptions(lineWidth, breakWords, wordSeparator, wordSplitter, wrapAlgorithm);
     draw_wrapped_text(ctx, options, text);
 }
 
 document.getElementById("text").addEventListener("input", redraw);
 document.getElementById("font-family").addEventListener("input", redraw);
+document.getElementById("break-words").addEventListener("input", redraw);
 document.getElementById("word-separator").addEventListener("input", redraw);
 document.getElementById("word-splitter").addEventListener("input", redraw);
 document.getElementById("wrap-algorithm").addEventListener("input", redraw);


### PR DESCRIPTION
This adds a checkbox to control breaking long words that don’t fit on a single line. The words are broken grapheme cluster boundaries, which ensures that combining diacritical marks will be kept together with their base character.