### PR TITLE
Move `WordSeparator` and `WordSplitter` traits to separate modules

### DIFF
--- a/benches/linear.rs
+++ b/benches/linear.rs
@@ -32,7 +32,7 @@ pub fn benchmark(c: &mut Criterion) {
             {
                 let options = textwrap::Options::new(LINE_LENGTH)
                     .wrap_algorithm(textwrap::wrap_algorithms::OptimalFit)
-                    .word_separator(textwrap::UnicodeBreakProperties);
+                    .word_separator(textwrap::word_separators::UnicodeBreakProperties);
                 group.bench_with_input(
                     BenchmarkId::new("fill_optimal_fit_unicode", length),
                     &text,
@@ -44,7 +44,7 @@ pub fn benchmark(c: &mut Criterion) {
 
             let options = textwrap::Options::new(LINE_LENGTH)
                 .wrap_algorithm(textwrap::wrap_algorithms::OptimalFit)
-                .word_separator(textwrap::AsciiSpace);
+                .word_separator(textwrap::word_separators::AsciiSpace);
             group.bench_with_input(
                 BenchmarkId::new("fill_optimal_fit_ascii", length),
                 &text,
@@ -56,7 +56,7 @@ pub fn benchmark(c: &mut Criterion) {
 
         let options = textwrap::Options::new(LINE_LENGTH)
             .wrap_algorithm(textwrap::wrap_algorithms::FirstFit)
-            .word_separator(textwrap::AsciiSpace);
+            .word_separator(textwrap::word_separators::AsciiSpace);
         group.bench_with_input(
             BenchmarkId::new("fill_first_fit", length),
             &text,

--- a/examples/interactive.rs
+++ b/examples/interactive.rs
@@ -19,8 +19,8 @@ mod unix_only {
     use termion::raw::{IntoRawMode, RawTerminal};
     use termion::screen::AlternateScreen;
     use termion::{color, cursor, style};
-    use textwrap::wrap_algorithms;
-    use textwrap::{wrap, AsciiSpace, Options, WordSeparator};
+    use textwrap::{word_separators, wrap_algorithms};
+    use textwrap::{wrap, Options};
     use textwrap::{HyphenSplitter, NoHyphenation, WordSplitter};
 
     #[cfg(feature = "hyphenation")]
@@ -59,7 +59,7 @@ mod unix_only {
         options: &Options<
             'a,
             Box<dyn wrap_algorithms::WrapAlgorithm>,
-            Box<dyn WordSeparator>,
+            Box<dyn word_separators::WordSeparator>,
             Box<dyn WordSplitter>,
         >,
         splitter_label: &str,
@@ -266,7 +266,9 @@ mod unix_only {
             .break_words(false)
             .wrap_algorithm(wrap_algorithms.remove(0))
             .splitter(splitters.remove(0))
-            .word_separator(Box::new(AsciiSpace) as Box<dyn WordSeparator>);
+            .word_separator(
+                Box::new(word_separators::AsciiSpace) as Box<dyn word_separators::WordSeparator>
+            );
         let mut splitter_label = splitter_labels.remove(0);
 
         let args = std::env::args().collect::<Vec<_>>();

--- a/examples/interactive.rs
+++ b/examples/interactive.rs
@@ -19,9 +19,8 @@ mod unix_only {
     use termion::raw::{IntoRawMode, RawTerminal};
     use termion::screen::AlternateScreen;
     use termion::{color, cursor, style};
-    use textwrap::{word_separators, wrap_algorithms};
+    use textwrap::{word_separators, word_splitters, wrap_algorithms};
     use textwrap::{wrap, Options};
-    use textwrap::{HyphenSplitter, NoHyphenation, WordSplitter};
 
     #[cfg(feature = "hyphenation")]
     use hyphenation::{Language, Load, Standard};
@@ -60,7 +59,7 @@ mod unix_only {
             'a,
             Box<dyn wrap_algorithms::WrapAlgorithm>,
             Box<dyn word_separators::WordSeparator>,
-            Box<dyn WordSplitter>,
+            Box<dyn word_splitters::WordSplitter>,
         >,
         splitter_label: &str,
         stdout: &mut RawTerminal<io::Stdout>,
@@ -238,8 +237,10 @@ mod unix_only {
         #[cfg(feature = "smawk")]
         wrap_algorithms.push(Box::new(wrap_algorithms::OptimalFit));
 
-        let mut splitters: Vec<Box<dyn WordSplitter>> =
-            vec![Box::new(HyphenSplitter), Box::new(NoHyphenation)];
+        let mut splitters: Vec<Box<dyn word_splitters::WordSplitter>> = vec![
+            Box::new(word_splitters::HyphenSplitter),
+            Box::new(word_splitters::NoHyphenation),
+        ];
         let mut splitter_labels: Vec<String> =
             splitters.iter().map(|s| format!("{:?}", s)).collect();
 

--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -1,4 +1,5 @@
-use textwrap::{wrap, HyphenSplitter, Options, WordSplitter};
+use textwrap::word_splitters::{HyphenSplitter, WordSplitter};
+use textwrap::{wrap, Options};
 
 fn main() {
     let example = "Memory safety without garbage collection. \

--- a/examples/wasm/src/lib.rs
+++ b/examples/wasm/src/lib.rs
@@ -3,6 +3,7 @@ use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 
 use textwrap::core;
+use textwrap::word_separators::{AsciiSpace, UnicodeBreakProperties, WordSeparator};
 use textwrap::wrap_algorithms::{wrap_first_fit, wrap_optimal_fit};
 
 #[wasm_bindgen]
@@ -292,9 +293,9 @@ pub fn draw_wrapped_text(
     let line_height = metrics.actual_bounding_box_ascent() + metrics.actual_bounding_box_descent();
     let baseline_distance = 1.5 * line_height;
 
-    let word_separator: Box<dyn textwrap::WordSeparator> = match options.word_separator {
-        WasmWordSeparator::AsciiSpace => Box::new(textwrap::AsciiSpace),
-        WasmWordSeparator::UnicodeBreakProperties => Box::new(textwrap::UnicodeBreakProperties),
+    let word_separator: Box<dyn WordSeparator> = match options.word_separator {
+        WasmWordSeparator::AsciiSpace => Box::new(AsciiSpace),
+        WasmWordSeparator::UnicodeBreakProperties => Box::new(UnicodeBreakProperties),
         _ => Err("WasmOptions has an invalid word_separator field")?,
     };
 

--- a/examples/wasm/src/lib.rs
+++ b/examples/wasm/src/lib.rs
@@ -4,6 +4,7 @@ use wasm_bindgen::JsCast;
 
 use textwrap::core;
 use textwrap::word_separators::{AsciiSpace, UnicodeBreakProperties, WordSeparator};
+use textwrap::word_splitters::{split_words, HyphenSplitter, NoHyphenation, WordSplitter};
 use textwrap::wrap_algorithms::{wrap_first_fit, wrap_optimal_fit};
 
 #[wasm_bindgen]
@@ -299,16 +300,16 @@ pub fn draw_wrapped_text(
         _ => Err("WasmOptions has an invalid word_separator field")?,
     };
 
-    let word_splitter: Box<dyn textwrap::WordSplitter> = match options.word_splitter {
-        WasmWordSplitter::NoHyphenation => Box::new(textwrap::NoHyphenation),
-        WasmWordSplitter::HyphenSplitter => Box::new(textwrap::HyphenSplitter),
+    let word_splitter: Box<dyn WordSplitter> = match options.word_splitter {
+        WasmWordSplitter::NoHyphenation => Box::new(NoHyphenation),
+        WasmWordSplitter::HyphenSplitter => Box::new(HyphenSplitter),
         _ => Err("WasmOptions has an invalid word_splitter field")?,
     };
 
     let mut lineno = 0;
     for line in text.split('\n') {
         let words = word_separator.find_words(line);
-        let split_words = core::split_words(words, &word_splitter);
+        let split_words = split_words(words, &word_splitter);
 
         let canvas_words = split_words
             .flat_map(|word| {

--- a/src/core.rs
+++ b/src/core.rs
@@ -13,8 +13,10 @@
 //!    how to do this for text.
 //!
 //! 2. Potentially split your fragments into smaller pieces. This
-//!    allows you to implement things like hyphenation. If wrapping
-//!    text, [`split_words`] can help you do this.
+//!    allows you to implement things like hyphenation. If you are
+//!    wrapping text represented as a sequence of [`Word`]s, then you
+//!    can use [`split_words`](crate::word_splitters::split_words) can
+//!    help you do this.
 //!
 //! 3. Potentially break apart fragments that are still too large to
 //!    fit on a single line. This is implemented in [`break_words`].
@@ -32,8 +34,6 @@
 //! Please [open an issue](https://github.com/mgeisler/textwrap/) if
 //! the functionality here is not sufficient or if you have ideas for
 //! improving it. We would love to hear from you!
-
-use crate::WordSplitter;
 
 /// The CSI or “Control Sequence Introducer” introduces an ANSI escape
 /// sequence. This is typically used for colored text and will be
@@ -221,7 +221,7 @@ pub struct Word<'a> {
     /// Penalty string to insert if the word falls at the end of a line.
     pub penalty: &'a str,
     // Cached width in columns.
-    width: usize,
+    pub(crate) width: usize,
 }
 
 impl std::ops::Deref for Word<'_> {
@@ -323,70 +323,6 @@ impl Fragment for Word<'_> {
     }
 }
 
-/// Split words into smaller words according to the split points given
-/// by `options`.
-///
-/// Note that we split all words, regardless of their length. This is
-/// to more cleanly separate the business of splitting (including
-/// automatic hyphenation) from the business of word wrapping.
-///
-/// # Examples
-///
-/// ```
-/// use textwrap::core::{split_words, Word};
-/// use textwrap::{NoHyphenation, HyphenSplitter};
-///
-/// assert_eq!(
-///     split_words(vec![Word::from("foo-bar")], &HyphenSplitter).collect::<Vec<_>>(),
-///     vec![Word::from("foo-"), Word::from("bar")]
-/// );
-///
-/// // The NoHyphenation splitter ignores the '-':
-/// assert_eq!(
-///     split_words(vec![Word::from("foo-bar")], &NoHyphenation).collect::<Vec<_>>(),
-///     vec![Word::from("foo-bar")]
-/// );
-/// ```
-pub fn split_words<'a, I, WordSplit>(
-    words: I,
-    word_splitter: &'a WordSplit,
-) -> impl Iterator<Item = Word<'a>>
-where
-    I: IntoIterator<Item = Word<'a>>,
-    WordSplit: WordSplitter,
-{
-    words.into_iter().flat_map(move |word| {
-        let mut prev = 0;
-        let mut split_points = word_splitter.split_points(&word).into_iter();
-        std::iter::from_fn(move || {
-            if let Some(idx) = split_points.next() {
-                let need_hyphen = !word[..idx].ends_with('-');
-                let w = Word {
-                    word: &word.word[prev..idx],
-                    width: display_width(&word[prev..idx]),
-                    whitespace: "",
-                    penalty: if need_hyphen { "-" } else { "" },
-                };
-                prev = idx;
-                return Some(w);
-            }
-
-            if prev < word.word.len() || prev == 0 {
-                let w = Word {
-                    word: &word.word[prev..],
-                    width: display_width(&word[prev..]),
-                    whitespace: word.whitespace,
-                    penalty: word.penalty,
-                };
-                prev = word.word.len() + 1;
-                return Some(w);
-            }
-
-            None
-        })
-    })
-}
-
 /// Forcibly break words wider than `line_width` into smaller words.
 ///
 /// This simply calls [`Word::break_apart`] on words that are too
@@ -410,17 +346,9 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::HyphenSplitter;
 
     #[cfg(feature = "unicode-width")]
     use unicode_width::UnicodeWidthChar;
-
-    // Like assert_eq!, but the left expression is an iterator.
-    macro_rules! assert_iter_eq {
-        ($left:expr, $right:expr) => {
-            assert_eq!($left.collect::<Vec<_>>(), $right);
-        };
-    }
 
     #[test]
     fn skip_ansi_escape_sequence_works() {
@@ -502,81 +430,5 @@ mod tests {
     #[test]
     fn display_width_emojis() {
         assert_eq!(display_width("😂😭🥺🤣✨😍🙏🥰😊🔥"), 20);
-    }
-
-    #[test]
-    fn split_words_no_words() {
-        assert_iter_eq!(split_words(vec![], &HyphenSplitter), vec![]);
-    }
-
-    #[test]
-    fn split_words_empty_word() {
-        assert_iter_eq!(
-            split_words(vec![Word::from("   ")], &HyphenSplitter),
-            vec![Word::from("   ")]
-        );
-    }
-
-    #[test]
-    fn split_words_single_word() {
-        assert_iter_eq!(
-            split_words(vec![Word::from("foobar")], &HyphenSplitter),
-            vec![Word::from("foobar")]
-        );
-    }
-
-    #[test]
-    fn split_words_hyphen_splitter() {
-        assert_iter_eq!(
-            split_words(vec![Word::from("foo-bar")], &HyphenSplitter),
-            vec![Word::from("foo-"), Word::from("bar")]
-        );
-    }
-
-    #[test]
-    fn split_words_adds_penalty() {
-        #[derive(Clone, Debug)]
-        struct FixedSplitPoint;
-        impl WordSplitter for FixedSplitPoint {
-            fn split_points(&self, _: &str) -> Vec<usize> {
-                vec![3]
-            }
-        }
-
-        assert_iter_eq!(
-            split_words(vec![Word::from("foobar")].into_iter(), &FixedSplitPoint),
-            vec![
-                Word {
-                    word: "foo",
-                    width: 3,
-                    whitespace: "",
-                    penalty: "-"
-                },
-                Word {
-                    word: "bar",
-                    width: 3,
-                    whitespace: "",
-                    penalty: ""
-                }
-            ]
-        );
-
-        assert_iter_eq!(
-            split_words(vec![Word::from("fo-bar")].into_iter(), &FixedSplitPoint),
-            vec![
-                Word {
-                    word: "fo-",
-                    width: 3,
-                    whitespace: "",
-                    penalty: ""
-                },
-                Word {
-                    word: "bar",
-                    width: 3,
-                    whitespace: "",
-                    penalty: ""
-                }
-            ]
-        );
     }
 }

--- a/src/core.rs
+++ b/src/core.rs
@@ -9,8 +9,8 @@
 //!
 //! 1. Split your input into [`Fragment`]s. These are abstract blocks
 //!    of text or content which can be wrapped into lines. See
-//!    [`WordSeparator`](crate::WordSeparator) for how to do this for
-//!    text.
+//!    [`WordSeparator`](crate::word_separators::WordSeparator) for
+//!    how to do this for text.
 //!
 //! 2. Potentially split your fragments into smaller pieces. This
 //!    allows you to implement things like hyphenation. If wrapping

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,8 +138,8 @@
 //!   This feature can be disabled if you are happy to find words
 //!   separated by ASCII space characters only. People wrapping text
 //!   with emojis or East-Asian characters will want most likely want
-//!   to enable this feature. See the [`WordSeparator`] trait for
-//!   details.
+//!   to enable this feature. See the
+//!   [`word_separators::WordSeparator`] trait for details.
 //!
 //! * `unicode-width`: enables correct width computation of non-ASCII
 //!   characters via the [unicode-width] crate. Without this feature,
@@ -192,12 +192,8 @@ pub use crate::indentation::indent;
 mod splitting;
 pub use crate::splitting::{HyphenSplitter, NoHyphenation, WordSplitter};
 
+pub mod word_separators;
 pub mod wrap_algorithms;
-
-mod word_separator;
-#[cfg(feature = "unicode-linebreak")]
-pub use word_separator::UnicodeBreakProperties;
-pub use word_separator::{AsciiSpace, WordSeparator};
 
 pub mod core;
 
@@ -220,14 +216,14 @@ macro_rules! DefaultWrapAlgorithm {
 #[cfg(feature = "unicode-linebreak")]
 macro_rules! DefaultWordSeparator {
     () => {
-        UnicodeBreakProperties
+        word_separators::UnicodeBreakProperties
     };
 }
 
 #[cfg(not(feature = "unicode-linebreak"))]
 macro_rules! DefaultWordSeparator {
     () => {
-        AsciiSpace
+        word_separators::AsciiSpace
     };
 }
 
@@ -236,7 +232,7 @@ macro_rules! DefaultWordSeparator {
 pub struct Options<
     'a,
     WrapAlgo = Box<dyn wrap_algorithms::WrapAlgorithm>,
-    WordSep = Box<dyn WordSeparator>,
+    WordSep = Box<dyn word_separators::WordSeparator>,
     WordSplit = Box<dyn WordSplitter>,
 > {
     /// The width in columns at which the text will be wrapped.
@@ -254,8 +250,9 @@ pub struct Options<
     /// Wrapping algorithm to use, see the implementations of the
     /// [`wrap_algorithms::WrapAlgorithm`] trait for details.
     pub wrap_algorithm: WrapAlgo,
-    /// The line breaking algorithm to use, see [`WordSeparator`]
-    /// trait for an overview and possible implementations.
+    /// The line breaking algorithm to use, see
+    /// [`word_separators::WordSeparator`] trait for an overview and
+    /// possible implementations.
     pub word_separator: WordSep,
     /// The method for splitting words. This can be used to prohibit
     /// splitting words on hyphens, or it can be used to implement
@@ -298,9 +295,7 @@ impl<'a> Options<'a, DefaultWrapAlgorithm!(), DefaultWordSeparator!(), HyphenSpl
     /// dispatch using the [`HyphenSplitter`]. Equivalent to
     ///
     /// ```
-    /// # use textwrap::{AsciiSpace, Options, HyphenSplitter, WordSplitter};
-    /// # #[cfg(feature = "unicode-linebreak")]
-    /// # use textwrap::UnicodeBreakProperties;
+    /// # use textwrap::{Options, HyphenSplitter, WordSplitter};
     /// # let width = 80;
     /// # let actual = Options::new(width);
     /// # let expected =
@@ -310,9 +305,9 @@ impl<'a> Options<'a, DefaultWrapAlgorithm!(), DefaultWordSeparator!(), HyphenSpl
     ///     subsequent_indent: "",
     ///     break_words: true,
     ///     #[cfg(feature = "unicode-linebreak")]
-    ///     word_separator: UnicodeBreakProperties,
+    ///     word_separator: textwrap::word_separators::UnicodeBreakProperties,
     ///     #[cfg(not(feature = "unicode-linebreak"))]
-    ///     word_separator: AsciiSpace,
+    ///     word_separator: textwrap::word_separators::AsciiSpace,
     ///     #[cfg(feature = "smawk")]
     ///     wrap_algorithm: textwrap::wrap_algorithms::OptimalFit,
     ///     #[cfg(not(feature = "smawk"))]
@@ -339,7 +334,7 @@ impl<'a> Options<'a, DefaultWrapAlgorithm!(), DefaultWordSeparator!(), HyphenSpl
     /// a `Box<dyn WordSplitter>`. This way the splitter's inner type
     /// can be changed without changing the type of this struct, which
     /// then would be just `Options` as a short cut for
-    /// `Options<Box<dyn WordSeparator>, Box<dyn WordSplitter>>`.
+    /// `Options<Box<dyn word_separators::WordSeparator>, Box<dyn WordSplitter>>`.
     ///
     /// The value and type of the splitter can be choose from the
     /// start using the [`Options::with_splitter`] constructor or
@@ -350,7 +345,8 @@ impl<'a> Options<'a, DefaultWrapAlgorithm!(), DefaultWordSeparator!(), HyphenSpl
     ///
     /// ```
     /// use textwrap::{HyphenSplitter, NoHyphenation, Options};
-    /// # use textwrap::{AsciiSpace, WordSplitter};
+    /// # use textwrap::WordSplitter;
+    /// # use textwrap::word_separators::AsciiSpace;
     /// # let width = 80;
     ///
     /// // uses HyphenSplitter with static dispatch
@@ -406,9 +402,7 @@ impl<'a, WordSplit> Options<'a, DefaultWrapAlgorithm!(), DefaultWordSeparator!()
     /// splitter. Equivalent to
     ///
     /// ```
-    /// # use textwrap::{AsciiSpace, Options, NoHyphenation, HyphenSplitter};
-    /// # #[cfg(feature = "unicode-linebreak")]
-    /// # use textwrap::UnicodeBreakProperties;
+    /// # use textwrap::{Options, NoHyphenation, HyphenSplitter};
     /// # const splitter: NoHyphenation = NoHyphenation;
     /// # const width: usize = 80;
     /// # let actual = Options::with_splitter(width, splitter);
@@ -419,9 +413,9 @@ impl<'a, WordSplit> Options<'a, DefaultWrapAlgorithm!(), DefaultWordSeparator!()
     ///     subsequent_indent: "",
     ///     break_words: true,
     ///     #[cfg(feature = "unicode-linebreak")]
-    ///     word_separator: UnicodeBreakProperties,
+    ///     word_separator: textwrap::word_separators::UnicodeBreakProperties,
     ///     #[cfg(not(feature = "unicode-linebreak"))]
-    ///     word_separator: textwrap::AsciiSpace,
+    ///     word_separator: textwrap::word_separators::AsciiSpace,
     ///     #[cfg(feature = "smawk")]
     ///     wrap_algorithm: textwrap::wrap_algorithms::OptimalFit,
     ///     #[cfg(not(feature = "smawk"))]
@@ -467,7 +461,8 @@ impl<'a, WordSplit> Options<'a, DefaultWrapAlgorithm!(), DefaultWordSeparator!()
     /// context:
     ///
     /// ```
-    /// use textwrap::{HyphenSplitter, Options, AsciiSpace};
+    /// use textwrap::{HyphenSplitter, Options};
+    /// use textwrap::word_separators::AsciiSpace;
     /// use textwrap::wrap_algorithms::FirstFit;
     /// # const width: usize = 80;
     ///
@@ -581,7 +576,7 @@ impl<'a, WrapAlgo, WordSep, WordSplit> Options<'a, WrapAlgo, WordSep, WordSplit>
 
     /// Change [`self.word_separator`].
     ///
-    /// See [`WordSeparator`] for details on the choices.
+    /// See [`word_separators::WordSeparator`] for details on the choices.
     ///
     /// [`self.word_separator`]: #structfield.word_separator
     pub fn word_separator<NewWordSep>(
@@ -716,7 +711,7 @@ pub fn termwidth() -> usize {
 pub fn fill<'a, WrapAlgo, WordSep, WordSplit, Opt>(text: &str, width_or_options: Opt) -> String
 where
     WrapAlgo: wrap_algorithms::WrapAlgorithm,
-    WordSep: WordSeparator,
+    WordSep: word_separators::WordSeparator,
     WordSplit: WordSplitter,
     Opt: Into<Options<'a, WrapAlgo, WordSep, WordSplit>>,
 {
@@ -886,7 +881,7 @@ pub fn refill<'a, WrapAlgo, WordSep, WordSplit, Opt>(
 ) -> String
 where
     WrapAlgo: wrap_algorithms::WrapAlgorithm,
-    WordSep: WordSeparator,
+    WordSep: word_separators::WordSeparator,
     WordSplit: WordSplitter,
     Opt: Into<Options<'a, WrapAlgo, WordSep, WordSplit>>,
 {
@@ -1075,7 +1070,7 @@ pub fn wrap<'a, WrapAlgo, WordSep, WordSplit, Opt>(
 ) -> Vec<Cow<'_, str>>
 where
     WrapAlgo: wrap_algorithms::WrapAlgorithm,
-    WordSep: WordSeparator,
+    WordSep: word_separators::WordSeparator,
     WordSplit: WordSplitter,
     Opt: Into<Options<'a, WrapAlgo, WordSep, WordSplit>>,
 {
@@ -1227,7 +1222,7 @@ pub fn wrap_columns<'a, WrapAlgo, WordSep, WordSplit, Opt>(
 ) -> Vec<String>
 where
     WrapAlgo: wrap_algorithms::WrapAlgorithm,
-    WordSep: WordSeparator,
+    WordSep: word_separators::WordSeparator,
     WordSplit: WordSplitter,
     Opt: Into<Options<'a, WrapAlgo, WordSep, WordSplit>>,
 {
@@ -1288,15 +1283,15 @@ where
 /// [`fill`] with these options:
 ///
 /// ```
-/// # use textwrap::{core, AsciiSpace, Options, NoHyphenation};
-/// # use textwrap::wrap_algorithms;
+/// # use textwrap::{core, Options, NoHyphenation};
+/// # use textwrap::{word_separators, wrap_algorithms};
 /// # let width = 80;
 /// Options {
 ///     width: width,
 ///     initial_indent: "",
 ///     subsequent_indent: "",
 ///     break_words: false,
-///     word_separator: AsciiSpace,
+///     word_separator: word_separators::AsciiSpace,
 ///     wrap_algorithm: wrap_algorithms::FirstFit,
 ///     splitter: NoHyphenation,
 /// };
@@ -1328,11 +1323,14 @@ where
 /// benchmark](https://github.com/mgeisler/textwrap/blob/master/benches/linear.rs)
 /// for details.
 pub fn fill_inplace(text: &mut String, width: usize) {
+    use word_separators::WordSeparator;
     let mut indices = Vec::new();
 
     let mut offset = 0;
     for line in text.split('\n') {
-        let words = AsciiSpace.find_words(line).collect::<Vec<_>>();
+        let words = word_separators::AsciiSpace
+            .find_words(line)
+            .collect::<Vec<_>>();
         let wrapped_words = wrap_algorithms::wrap_first_fit(&words, &[width]);
 
         let mut line_offset = offset;
@@ -1460,7 +1458,7 @@ mod tests {
     fn issue_129() {
         // The dash is an em-dash which takes up four bytes. We used
         // to panic since we tried to index into the character.
-        let options = Options::new(1).word_separator(AsciiSpace);
+        let options = Options::new(1).word_separator(word_separators::AsciiSpace);
         assert_eq!(wrap("x – x", options), vec!["x", "–", "x"]);
     }
 
@@ -1471,7 +1469,7 @@ mod tests {
         assert_eq!(
             wrap(
                 "Ｈｅｌｌｏ, Ｗｏｒｌｄ!",
-                Options::new(15).word_separator(AsciiSpace)
+                Options::new(15).word_separator(word_separators::AsciiSpace)
             ),
             vec!["Ｈｅｌｌｏ,", "Ｗｏｒｌｄ!"]
         );
@@ -1482,7 +1480,7 @@ mod tests {
         assert_eq!(
             wrap(
                 "Ｈｅｌｌｏ, Ｗｏｒｌｄ!",
-                Options::new(15).word_separator(UnicodeBreakProperties)
+                Options::new(15).word_separator(word_separators::UnicodeBreakProperties)
             ),
             vec!["Ｈｅｌｌｏ, Ｗ", "ｏｒｌｄ!"]
         );
@@ -1747,7 +1745,7 @@ mod tests {
     fn break_words_wide_characters() {
         // Even the poor man's version of `ch_width` counts these
         // characters as wide.
-        let options = Options::new(5).word_separator(AsciiSpace);
+        let options = Options::new(5).word_separator(word_separators::AsciiSpace);
         assert_eq!(wrap("Ｈｅｌｌｏ", options), vec!["Ｈｅ", "ｌｌ", "ｏ"]);
     }
 
@@ -1838,8 +1836,11 @@ mod tests {
     #[cfg(not(feature = "smawk"))]
     #[cfg(not(feature = "unicode-linebreak"))]
     fn cloning_works() {
-        static OPT: Options<wrap_algorithms::FirstFit, AsciiSpace, HyphenSplitter> =
-            Options::with_splitter(80, HyphenSplitter);
+        static OPT: Options<
+            wrap_algorithms::FirstFit,
+            word_separators::AsciiSpace,
+            HyphenSplitter,
+        > = Options::with_splitter(80, HyphenSplitter);
         #[allow(clippy::clone_on_copy)]
         let opt = OPT.clone();
         assert_eq!(opt.width, 80);
@@ -1983,14 +1984,21 @@ mod tests {
     #[test]
     fn trait_object_vec() {
         // Create a vector of Options containing trait-objects.
-        let mut vector: Vec<Options<_, Box<dyn WordSeparator>, Box<dyn WordSplitter>>> = Vec::new();
+        let mut vector: Vec<
+            Options<_, Box<dyn word_separators::WordSeparator>, Box<dyn WordSplitter>>,
+        > = Vec::new();
         // Expected result from each options
         let mut results = Vec::new();
 
-        let opt_full_type: Options<_, Box<dyn WordSeparator>, Box<dyn WordSplitter>> =
-            Options::new(10)
-                .splitter(Box::new(HyphenSplitter) as Box<dyn WordSplitter>)
-                .word_separator(Box::new(AsciiSpace) as Box<dyn WordSeparator>);
+        let opt_full_type: Options<
+            _,
+            Box<dyn word_separators::WordSeparator>,
+            Box<dyn WordSplitter>,
+        > = Options::new(10)
+            .splitter(Box::new(HyphenSplitter) as Box<dyn WordSplitter>)
+            .word_separator(
+                Box::new(word_separators::AsciiSpace) as Box<dyn word_separators::WordSeparator>
+            );
         vector.push(opt_full_type);
         results.push(vec!["over-", "caffinated"]);
 
@@ -1998,7 +2006,9 @@ mod tests {
         let opt_abbreviated_type = Options::new(10)
             .break_words(false)
             .splitter(Box::new(NoHyphenation) as Box<dyn WordSplitter>)
-            .word_separator(Box::new(AsciiSpace) as Box<dyn WordSeparator>);
+            .word_separator(
+                Box::new(word_separators::AsciiSpace) as Box<dyn word_separators::WordSeparator>
+            );
         vector.push(opt_abbreviated_type);
         results.push(vec!["over-caffinated"]);
 
@@ -2007,7 +2017,8 @@ mod tests {
             let dictionary = Standard::from_embedded(Language::EnglishUS).unwrap();
             let opt_hyp = Options::new(8)
                 .splitter(Box::new(dictionary) as Box<dyn WordSplitter>)
-                .word_separator(Box::new(AsciiSpace) as Box<dyn WordSeparator>);
+                .word_separator(Box::new(word_separators::AsciiSpace)
+                    as Box<dyn word_separators::WordSeparator>);
             vector.push(opt_hyp);
             results.push(vec!["over-", "caffi-", "nated"]);
         }

--- a/src/word_separators.rs
+++ b/src/word_separators.rs
@@ -1,4 +1,18 @@
-//! Line breaking functionality.
+//! Functionality for finding words.
+//!
+//! In order to wrap text, we need to know where the legal break
+//! points are, i.e., where the words of the text are. This means that
+//! we need to define what a "word" is.
+//!
+//! A simple approach is to simply split the text on whitespace, but
+//! this does not work for East-Asian languages such as Chinese or
+//! Japanese where there are no spaces between words. Breaking a long
+//! sequence of emojis is another example where line breaks might be
+//! wanted even if there are no whitespace to be found.
+//!
+//! The [`WordSeparator`] trait is responsible for determining where
+//! there words are in a line of text. Please refer to the trait and
+//! the structs which implement it for more information.
 
 #[cfg(feature = "unicode-linebreak")]
 use crate::core::skip_ansi_escape_sequence;
@@ -18,8 +32,9 @@ use crate::core::Word;
 /// # Examples
 ///
 /// ```
-/// use textwrap::{WordSeparator, AsciiSpace};
 /// use textwrap::core::Word;
+/// use textwrap::word_separators::{WordSeparator, AsciiSpace};
+///
 /// let words = AsciiSpace.find_words("Hello World!").collect::<Vec<_>>();
 /// assert_eq!(words, vec![Word::from("Hello "), Word::from("World!")]);
 /// ```
@@ -35,6 +50,7 @@ pub trait WordSeparator: WordSeparatorClone + std::fmt::Debug {
 // `Clone` for `Box<dyn WordSeparator>`. This in used in the
 // `From<&Options<'_, WrapAlgo, WordSep, WordSplit>> for Options<'a,
 // WrapAlgo, WordSep, WordSplit>` implementation.
+#[doc(hidden)]
 pub trait WordSeparatorClone {
     fn clone_box(&self) -> Box<dyn WordSeparator>;
 }
@@ -69,7 +85,7 @@ pub struct AsciiSpace;
 ///
 /// ```
 /// use textwrap::core::Word;
-/// use textwrap::{AsciiSpace, WordSeparator};
+/// use textwrap::word_separators::{AsciiSpace, WordSeparator};
 ///
 /// let words = AsciiSpace.find_words("Hello   World!").collect::<Vec<_>>();
 /// assert_eq!(words, vec![Word::from("Hello   "),
@@ -134,7 +150,7 @@ pub struct UnicodeBreakProperties;
 ///
 /// ```
 /// #[cfg(feature = "unicode-linebreak")] {
-/// use textwrap::{WordSeparator, UnicodeBreakProperties};
+/// use textwrap::word_separators::{WordSeparator, UnicodeBreakProperties};
 /// use textwrap::core::Word;
 ///
 /// assert_eq!(UnicodeBreakProperties.find_words("Emojis: 😂😍").collect::<Vec<_>>(),
@@ -154,7 +170,7 @@ pub struct UnicodeBreakProperties;
 ///
 /// ```
 /// #[cfg(feature = "unicode-linebreak")] {
-/// use textwrap::{UnicodeBreakProperties, WordSeparator};
+/// use textwrap::word_separators::{UnicodeBreakProperties, WordSeparator};
 /// use textwrap::core::Word;
 ///
 /// assert_eq!(UnicodeBreakProperties.find_words("Emojis: 😂\u{2060}😍").collect::<Vec<_>>(),
@@ -168,7 +184,7 @@ pub struct UnicodeBreakProperties;
 ///
 /// ```
 /// #[cfg(feature = "unicode-linebreak")] {
-/// use textwrap::{UnicodeBreakProperties, WordSeparator};
+/// use textwrap::word_separators::{UnicodeBreakProperties, WordSeparator};
 /// use textwrap::core::Word;
 ///
 /// assert_eq!(UnicodeBreakProperties.find_words("[ foo ] bar !").collect::<Vec<_>>(),

--- a/src/word_separators.rs
+++ b/src/word_separators.rs
@@ -26,8 +26,8 @@ use crate::core::Word;
 /// breaking algorithm, which finds break points in non-ASCII text.
 ///
 /// The line breaks occur between words, please see the
-/// [`WordSplitter`](crate::WordSplitter) trait for options of how
-/// to handle hyphenation of individual words.
+/// [`WordSplitter`](crate::word_splitters::WordSplitter) trait for
+/// options of how to handle hyphenation of individual words.
 ///
 /// # Examples
 ///
@@ -139,8 +139,8 @@ pub struct UnicodeBreakProperties;
 /// to break lines. There is a small difference in that the U+002D
 /// (Hyphen-Minus) and U+00AD (Soft Hyphen) don’t create a line break:
 /// to allow a line break at a hyphen, use the
-/// [`HyphenSplitter`](super::HyphenSplitter). Soft hyphens are not
-/// currently supported.
+/// [`HyphenSplitter`](crate::word_splitters::HyphenSplitter). Soft
+/// hyphens are not currently supported.
 ///
 /// # Examples
 ///

--- a/src/wrap_algorithms.rs
+++ b/src/wrap_algorithms.rs
@@ -108,7 +108,7 @@ impl WrapAlgorithm for FirstFit {
 /// ```
 /// use textwrap::core::Word;
 /// use textwrap::wrap_algorithms;
-/// use textwrap::{AsciiSpace, WordSeparator};
+/// use textwrap::word_separators::{AsciiSpace, WordSeparator};
 ///
 /// // Helper to convert wrapped lines to a Vec<String>.
 /// fn lines_to_strings(lines: Vec<&[Word<'_>]>) -> Vec<String> {

--- a/tests/traits.rs
+++ b/tests/traits.rs
@@ -1,13 +1,12 @@
+use textwrap::word_separators::{AsciiSpace, WordSeparator};
 use textwrap::wrap_algorithms::{FirstFit, WrapAlgorithm};
 use textwrap::Options;
-use textwrap::{AsciiSpace, WordSeparator};
 use textwrap::{NoHyphenation, WordSplitter};
 
 /// Cleaned up type name.
 fn type_name<T: ?Sized>(_val: &T) -> String {
     std::any::type_name::<T>()
         .replace("alloc::boxed::Box", "Box")
-        .replace("textwrap::word_separator", "textwrap")
         .replace("textwrap::splitting", "textwrap")
 }
 
@@ -22,7 +21,7 @@ fn static_hyphensplitter() {
         format!(
             "textwrap::Options<{}, {}, {}>",
             "textwrap::wrap_algorithms::FirstFit",
-            "textwrap::AsciiSpace",
+            "textwrap::word_separators::AsciiSpace",
             "textwrap::HyphenSplitter"
         )
     );
@@ -34,7 +33,7 @@ fn static_hyphensplitter() {
         format!(
             "textwrap::Options<{}, {}, {}>",
             "textwrap::wrap_algorithms::FirstFit",
-            "textwrap::AsciiSpace",
+            "textwrap::word_separators::AsciiSpace",
             "textwrap::HyphenSplitter"
         )
     );
@@ -46,7 +45,7 @@ fn static_hyphensplitter() {
         format!(
             "textwrap::Options<{}, {}, {}>",
             "textwrap::wrap_algorithms::FirstFit",
-            "textwrap::AsciiSpace",
+            "textwrap::word_separators::AsciiSpace",
             "textwrap::HyphenSplitter"
         )
     );
@@ -64,7 +63,7 @@ fn box_static_nohyphenation() {
         format!(
             "textwrap::Options<{}, {}, {}>",
             "Box<textwrap::wrap_algorithms::FirstFit>",
-            "Box<textwrap::AsciiSpace>",
+            "Box<textwrap::word_separators::AsciiSpace>",
             "Box<textwrap::NoHyphenation>"
         )
     );
@@ -82,7 +81,7 @@ fn box_dyn_wordsplitter() {
         format!(
             "textwrap::Options<{}, {}, {}>",
             "Box<dyn textwrap::wrap_algorithms::WrapAlgorithm>",
-            "Box<dyn textwrap::WordSeparator>",
+            "Box<dyn textwrap::word_separators::WordSeparator>",
             "Box<dyn textwrap::WordSplitter>"
         )
     );

--- a/tests/traits.rs
+++ b/tests/traits.rs
@@ -1,13 +1,11 @@
 use textwrap::word_separators::{AsciiSpace, WordSeparator};
+use textwrap::word_splitters::{HyphenSplitter, NoHyphenation, WordSplitter};
 use textwrap::wrap_algorithms::{FirstFit, WrapAlgorithm};
 use textwrap::Options;
-use textwrap::{NoHyphenation, WordSplitter};
 
 /// Cleaned up type name.
 fn type_name<T: ?Sized>(_val: &T) -> String {
-    std::any::type_name::<T>()
-        .replace("alloc::boxed::Box", "Box")
-        .replace("textwrap::splitting", "textwrap")
+    std::any::type_name::<T>().replace("alloc::boxed::Box", "Box")
 }
 
 #[test]
@@ -22,19 +20,19 @@ fn static_hyphensplitter() {
             "textwrap::Options<{}, {}, {}>",
             "textwrap::wrap_algorithms::FirstFit",
             "textwrap::word_separators::AsciiSpace",
-            "textwrap::HyphenSplitter"
+            "textwrap::word_splitters::HyphenSplitter"
         )
     );
 
     // Inferring part of the type.
-    let options: Options<_, _, textwrap::HyphenSplitter> = Options::new(10);
+    let options: Options<_, _, HyphenSplitter> = Options::new(10);
     assert_eq!(
         type_name(&options),
         format!(
             "textwrap::Options<{}, {}, {}>",
             "textwrap::wrap_algorithms::FirstFit",
             "textwrap::word_separators::AsciiSpace",
-            "textwrap::HyphenSplitter"
+            "textwrap::word_splitters::HyphenSplitter"
         )
     );
 
@@ -46,7 +44,7 @@ fn static_hyphensplitter() {
             "textwrap::Options<{}, {}, {}>",
             "textwrap::wrap_algorithms::FirstFit",
             "textwrap::word_separators::AsciiSpace",
-            "textwrap::HyphenSplitter"
+            "textwrap::word_splitters::HyphenSplitter"
         )
     );
 }
@@ -64,7 +62,7 @@ fn box_static_nohyphenation() {
             "textwrap::Options<{}, {}, {}>",
             "Box<textwrap::wrap_algorithms::FirstFit>",
             "Box<textwrap::word_separators::AsciiSpace>",
-            "Box<textwrap::NoHyphenation>"
+            "Box<textwrap::word_splitters::NoHyphenation>"
         )
     );
 }
@@ -74,7 +72,7 @@ fn box_dyn_wordsplitter() {
     // Inferred dynamic type due to default type parameter.
     let options = Options::new(10)
         .wrap_algorithm(Box::new(FirstFit) as Box<dyn WrapAlgorithm>)
-        .splitter(Box::new(NoHyphenation) as Box<dyn WordSplitter>)
+        .splitter(Box::new(HyphenSplitter) as Box<dyn WordSplitter>)
         .word_separator(Box::new(AsciiSpace) as Box<dyn WordSeparator>);
     assert_eq!(
         type_name(&options),
@@ -82,7 +80,7 @@ fn box_dyn_wordsplitter() {
             "textwrap::Options<{}, {}, {}>",
             "Box<dyn textwrap::wrap_algorithms::WrapAlgorithm>",
             "Box<dyn textwrap::word_separators::WordSeparator>",
-            "Box<dyn textwrap::WordSplitter>"
+            "Box<dyn textwrap::word_splitters::WordSplitter>"
         )
     );
 }


### PR DESCRIPTION
The three main traits now all have their own module, and the `core` module is much slimmer:

* `wrap_algorithms` is for the `WrapAlgorithm` trait as well as the `wrap_first_fit` and `wrap_optimal_fit` functions.
* `word_separators` is for the `WordSeparator` trait.
* `word_splitters` is for the `WordSplitter` trait and the `split_words` helper function.