### PR TITLE
Rename `Options::splitter` to `Options::word_splitter`

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ automatic hyphenation for [about 70 languages][patterns] via
 high-quality TeX hyphenation patterns.
 
 Your program must load the hyphenation pattern and configure
-`Options::splitter` to use it:
+`Options::word_splitter` to use it:
 
 ```rust
 use hyphenation::{Language, Load, Standard};
@@ -83,7 +83,7 @@ use textwrap::Options;
 
 fn main() {
     let hyphenator = Standard::from_embedded(Language::EnglishUS).unwrap();
-    let options = Options::new(28).splitter(hyphenator);
+    let options = Options::new(28).word_splitter(hyphenator);
     let text = "textwrap: an efficient and powerful library for wrapping text.";
     println!("{}", fill(text, &options);
 }

--- a/benches/linear.rs
+++ b/benches/linear.rs
@@ -80,7 +80,7 @@ pub fn benchmark(c: &mut Criterion) {
                 .join("benches")
                 .join("la.standard.bincode");
             let dictionary = Standard::from_path(Language::Latin, &path).unwrap();
-            let options = options.splitter(dictionary);
+            let options = options.word_splitter(dictionary);
             group.bench_with_input(BenchmarkId::new("hyphenation", length), &text, |b, text| {
                 b.iter(|| textwrap::fill(text, &options));
             });

--- a/examples/hyphenation.rs
+++ b/examples/hyphenation.rs
@@ -12,6 +12,6 @@ fn main() {
 fn main() {
     let text = "textwrap: a small library for wrapping text.";
     let dictionary = Standard::from_embedded(Language::EnglishUS).unwrap();
-    let options = textwrap::Options::new(18).splitter(dictionary);
+    let options = textwrap::Options::new(18).word_splitter(dictionary);
     println!("{}", textwrap::fill(text, &options));
 }

--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -7,13 +7,13 @@ fn main() {
                    Zero-cost abstractions.";
     let mut prev_lines = vec![];
 
-    let mut options = Options::new(0).splitter(Box::new(HyphenSplitter) as Box<dyn WordSplitter>);
+    let mut options = Options::new(0).word_splitter(Box::new(HyphenSplitter) as Box<dyn WordSplitter>);
     #[cfg(feature = "hyphenation")]
     {
         use hyphenation::Load;
         let language = hyphenation::Language::EnglishUS;
         let dictionary = hyphenation::Standard::from_embedded(language).unwrap();
-        options.splitter = Box::new(dictionary);
+        options.word_splitter = Box::new(dictionary);
     }
 
     for width in 15..60 {

--- a/examples/termwidth.rs
+++ b/examples/termwidth.rs
@@ -21,7 +21,7 @@ fn main() {
     #[cfg(feature = "hyphenation")]
     let (msg, options) = (
         "with hyphenation",
-        Options::with_termwidth().splitter(
+        Options::with_termwidth().word_splitter(
             hyphenation::Standard::from_embedded(hyphenation::Language::EnglishUS).unwrap(),
         ),
     );

--- a/src/word_splitters.rs
+++ b/src/word_splitters.rs
@@ -24,7 +24,7 @@ use crate::core::{display_width, Word};
 ///
 ///     let text = "Oxidation is the loss of electrons.";
 ///     let dictionary = Standard::from_embedded(Language::EnglishUS).unwrap();
-///     let options = Options::new(8).splitter(dictionary);
+///     let options = Options::new(8).word_splitter(dictionary);
 ///     assert_eq!(wrap(text, &options), vec!["Oxida-",
 ///                                           "tion is",
 ///                                           "the loss",
@@ -82,19 +82,19 @@ impl WordSplitter for Box<dyn WordSplitter> {
     }
 }
 
-/// Use this as a [`Options.splitter`] to avoid any kind of
+/// Use this as a [`Options.word_splitter`] to avoid any kind of
 /// hyphenation:
 ///
 /// ```
 /// use textwrap::{wrap, Options};
 /// use textwrap::word_splitters::NoHyphenation;
 ///
-/// let options = Options::new(8).splitter(NoHyphenation);
+/// let options = Options::new(8).word_splitter(NoHyphenation);
 /// assert_eq!(wrap("foo bar-baz", &options),
 ///            vec!["foo", "bar-baz"]);
 /// ```
 ///
-/// [`Options.splitter`]: super::Options::splitter
+/// [`Options.word_splitter`]: super::Options::word_splitter
 #[derive(Clone, Copy, Debug)]
 pub struct NoHyphenation;
 

--- a/tests/traits.rs
+++ b/tests/traits.rs
@@ -54,7 +54,7 @@ fn box_static_nohyphenation() {
     // Inferred static type.
     let options = Options::new(10)
         .wrap_algorithm(Box::new(FirstFit))
-        .splitter(Box::new(NoHyphenation))
+        .word_splitter(Box::new(NoHyphenation))
         .word_separator(Box::new(AsciiSpace));
     assert_eq!(
         type_name(&options),
@@ -72,7 +72,7 @@ fn box_dyn_wordsplitter() {
     // Inferred dynamic type due to default type parameter.
     let options = Options::new(10)
         .wrap_algorithm(Box::new(FirstFit) as Box<dyn WrapAlgorithm>)
-        .splitter(Box::new(HyphenSplitter) as Box<dyn WordSplitter>)
+        .word_splitter(Box::new(HyphenSplitter) as Box<dyn WordSplitter>)
         .word_separator(Box::new(AsciiSpace) as Box<dyn WordSeparator>);
     assert_eq!(
         type_name(&options),


### PR DESCRIPTION
This makes the field consistent with the `wrap_algorithm` and `word_separator` fields.