### PR TITLE
Generate high-quality source-map for Wasm demo

### DIFF
--- a/examples/wasm/www/webpack.config.js
+++ b/examples/wasm/www/webpack.config.js
@@ -8,6 +8,7 @@ module.exports = {
     filename: "bootstrap.js",
   },
   mode: "development",
+  devtool: "source-map",
   plugins: [
     new CopyWebpackPlugin({patterns: ['index.html', '../README.md', "build-info.json"]})
   ],


### PR DESCRIPTION
While this setting is supposed to be the slowest, our demo is so tiny that it is practically instant.