### PR TITLE
Update `hyphenation` to v0.8.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,7 @@ unicode-linebreak = { version = "0.1", optional = true }
 unicode-width = { version= "0.1", optional = true }
 
 [dependencies.hyphenation]
-git = "https://github.com/tapeinosyne/hyphenation"
-rev = "d8d501a3731d"  # Until `Standard` implements `Clone`
+version = "0.8.2"
 optional = true
 features = ["embed_en-us"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,15 +29,11 @@ path = "benches/indent.rs"
 default = ["unicode-linebreak", "unicode-width", "smawk"]
 
 [dependencies]
+hyphenation = { version = "0.8.2", optional = true, features = ["embed_en-us"] }
 smawk = { version = "0.3", optional = true }
 terminal_size = { version = "0.1", optional = true }
 unicode-linebreak = { version = "0.1", optional = true }
 unicode-width = { version= "0.1", optional = true }
-
-[dependencies.hyphenation]
-version = "0.8.2"
-optional = true
-features = ["embed_en-us"]
 
 [dev-dependencies]
 criterion = "0.3"


### PR DESCRIPTION
I observe one test failing on my machine, but it does so with `hyphenation` disabled as well:

```
thread 'core::tests::display_width_emojis' panicked at 'assertion failed: `(left == right)`
  left: `18`,
 right: `20`', src/core.rs:432:9
```

Perhaps more importantly, CI fails on `deploy WASM demo`: https://github.com/tapeinosyne/textwrap/runs/2740901118?check_suite_focus=true

I am unfamiliar with how textwrap compiles to WASM, which means I have little to contribute on the issue. However, do let me know if further changes are needed on my end.

