### PR TITLE
Update `hyphenation` to v0.8.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ path = "benches/indent.rs"
 default = ["unicode-linebreak", "unicode-width", "smawk"]
 
 [dependencies]
-hyphenation = { version = "0.8.2", optional = true, features = ["embed_en-us"] }
+hyphenation = { version = "0.8.3", optional = true, features = ["embed_en-us"] }
 smawk = { version = "0.3", optional = true }
 terminal_size = { version = "0.1", optional = true }
 unicode-linebreak = { version = "0.1", optional = true }


### PR DESCRIPTION
No functional changes for `textwrap`: the English dictionary is now built with an updated version of `bincode`.