### PR TITLE
Fix panic in `find_words` due to string access outside of a character boundary

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1852,6 +1852,12 @@ mod tests {
     }
 
     #[test]
+    fn fill_unicode_boundary() {
+        // https://github.com/mgeisler/textwrap/issues/390
+        fill("\u{1b}!Ͽ", 10);
+    }
+
+    #[test]
     #[cfg(not(feature = "smawk"))]
     #[cfg(not(feature = "unicode-linebreak"))]
     fn cloning_works() {

--- a/src/word_separators.rs
+++ b/src/word_separators.rs
@@ -216,7 +216,7 @@ impl WordSeparator for UnicodeBreakProperties {
         let mut opportunities = unicode_linebreak::linebreaks(&stripped)
             .filter(|(idx, _)| {
                 #[allow(clippy::match_like_matches_macro)]
-                match &line[..*idx].chars().next_back() {
+                match &stripped[..*idx].chars().next_back() {
                     // We suppress breaks at ‘-’ since we want to control
                     // this via the WordSplitter.
                     Some('-') => false,


### PR DESCRIPTION
Closes https://github.com/mgeisler/textwrap/issues/390

This fixes an attempt to access string bytes that may be within a character boundary.

Please check if this is actually how the code should be. All I know is that all tests pass.