### PR TITLE
Cache cargo-fuzz between invocations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,7 +129,10 @@ jobs:
           restore-keys: |
             fuzz-corpus-
 
-      - name: 30 second fuzz test
+      - name: Build fuzz targets
+        run: cargo fuzz build fill_first_fit
+
+      - name: Fuzz test
         run: cargo fuzz run fill_first_fit -- -max_total_time=30
 
   wasm-build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,6 +120,15 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: cargo install cargo-fuzz
 
+      - name: Cache fuzz corpus
+        id: cache-fuzz-corpus
+        uses: actions/cache@v2
+        with:
+          path: fuzz/corpus
+          key: fuzz-corpus-${{ github.run_id }}
+          restore-keys: |
+            fuzz-corpus-
+
       - name: 30 second fuzz test
         run: cargo fuzz run fill_first_fit -- -max_total_time=30
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,7 +103,21 @@ jobs:
       - name: Install nightly Rust
         run: rustup default nightly
 
+      - name: Get latest cargo-fuzz version
+        id: cargo-fuzz-version
+        run: |
+          VERSION=$(cargo search cargo-fuzz | grep cargo-fuzz | cut -d '"' -f 2)
+          echo "::set-output name=version::$VERSION"
+
+      - name: Cache cargo-fuzz
+        id: cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.cargo/bin/cargo-fuzz
+          key: cargo-fuzz-${{ steps.cargo-fuzz-version.outputs.version }}
+
       - name: Install cargo-fuzz
+        if: steps.cache.outputs.cache-hit != 'true'
         run: cargo install cargo-fuzz
 
       - name: 30 second fuzz test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,6 +135,9 @@ jobs:
       - name: Fuzz test
         run: cargo fuzz run fill_first_fit -- -max_total_time=30
 
+      - name: Minimize fuzz corpus
+        run: cargo fuzz cmin fill_first_fit
+
   wasm-build:
     name: Build Wasm demo
     runs-on: ubuntu-latest


### PR DESCRIPTION
This will make multiple runs on the same day faster since they can
reuse the cache. Fuzzing uses nightly Rust, so the cache will expire
daily.