### PR TITLE
add fill_optimal_fit fuzz target to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,13 +132,19 @@ jobs:
             fuzz-corpus-
 
       - name: Build fuzz targets
-        run: cargo fuzz build fill_first_fit
+        run: |
+          cargo fuzz build fill_first_fit
+          cargo fuzz build fill_optimal_fit
 
       - name: Fuzz test
-        run: cargo fuzz run fill_first_fit -- -max_total_time=30
+        run: |
+          cargo fuzz run fill_first_fit -- -max_total_time=30
+          cargo fuzz run fill_optimal_fit -- -max_total_time=30
 
       - name: Minimize fuzz corpus
-        run: cargo fuzz cmin fill_first_fit
+        run: |
+          cargo fuzz cmin fill_first_fit
+          cargo fuzz cmin fill_optimal_fit
 
   wasm-build:
     name: Build Wasm demo

--- a/fuzz/fuzz_targets/fill_optimal_fit.rs
+++ b/fuzz/fuzz_targets/fill_optimal_fit.rs
@@ -4,6 +4,6 @@ use textwrap::wrap_algorithms;
 use textwrap::Options;
 
 fuzz_target!(|input: (String, usize)| {
-    let options = Options::new(input.1).wrap_algorithm(wrap_algorithms::OptimalFit);
+    let options = Options::new(input.1).wrap_algorithm(wrap_algorithms::OptimalFit::default());
     let _ = textwrap::fill(&input.0, &options);
 });


### PR DESCRIPTION
I noticed that the `fill_optimal_fit` fuzz target was not run in CI so this PR makes the build workflow run this target right after `fill_first_fit`. `fill_first_fit` alone does not catch [this issue](https://github.com/mgeisler/textwrap/pull/392).