### PR TITLE
Configure required features for examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,14 @@ license = "MIT"
 edition = "2018"
 exclude = [".github/", ".gitignore", "benches/", "examples/", "fuzz/", "images/"]
 
+[[example]]
+name = "hyphenation"
+required-features = ["hyphenation"]
+
+[[example]]
+name = "termwidth"
+required-features = ["terminal_size"]
+
 [package.metadata.docs.rs]
 all-features = true
 

--- a/examples/hyphenation.rs
+++ b/examples/hyphenation.rs
@@ -1,14 +1,5 @@
-#[cfg(feature = "hyphenation")]
 use hyphenation::{Language, Load, Standard};
 
-#[cfg(not(feature = "hyphenation"))]
-fn main() {
-    println!("Please run this example as");
-    println!();
-    println!("  cargo run --example hyphenation --features hyphenation");
-}
-
-#[cfg(feature = "hyphenation")]
 fn main() {
     let text = "textwrap: a small library for wrapping text.";
     let dictionary = Standard::from_embedded(Language::EnglishUS).unwrap();

--- a/examples/termwidth.rs
+++ b/examples/termwidth.rs
@@ -1,12 +1,5 @@
-#[cfg(feature = "terminal_size")]
 use textwrap::{fill, Options};
 
-#[cfg(not(feature = "terminal_size"))]
-fn main() {
-    println!("Please enable the terminal_size Cargo feature to run this example.");
-}
-
-#[cfg(feature = "terminal_size")]
 fn main() {
     let example = "Memory safety without garbage collection. \
                    Concurrency without data races. \


### PR DESCRIPTION
Instead of manually checking for required features in the hyphenation
and termwidth examples, we can configure the required features in
Cargo.toml.  This makes the examples easier to read and maintain.