### PR TITLE
Rename `Fragment` to `MeasuredFragment`

### DIFF
--- a/examples/wasm/Cargo.lock
+++ b/examples/wasm/Cargo.lock
@@ -129,7 +129,7 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.14.0"
+version = "0.14.2"
 dependencies = [
  "smawk",
  "unicode-linebreak",

--- a/examples/wasm/src/lib.rs
+++ b/examples/wasm/src/lib.rs
@@ -148,7 +148,7 @@ impl<'a> CanvasWord<'a> {
 
 const PRECISION: usize = 10;
 
-impl core::Fragment for CanvasWord<'_> {
+impl core::MeasuredFragment for CanvasWord<'_> {
     #[inline]
     fn width(&self) -> usize {
         (self.width * PRECISION as f64) as usize

--- a/src/core.rs
+++ b/src/core.rs
@@ -7,8 +7,8 @@
 //! In general, you want to follow these steps when wrapping
 //! something:
 //!
-//! 1. Split your input into [`Fragment`]s. These are abstract blocks
-//!    of text or content which can be wrapped into lines. See
+//! 1. Split your input into [`MeasuredFragment`]s. These are abstract
+//!    blocks of text or content which can be wrapped into lines. See
 //!    [`WordSeparator`](crate::word_separators::WordSeparator) for
 //!    how to do this for text.
 //!
@@ -187,7 +187,7 @@ pub fn display_width(text: &str) -> usize {
 
 /// A (text) fragment denotes the unit which we wrap into lines.
 ///
-/// Fragments represent an abstract _word_ plus the _whitespace_
+/// MeasuredFragments represent an abstract _word_ plus the _whitespace_
 /// following the word. In case the word falls at the end of the line,
 /// the whitespace is dropped and a so-called _penalty_ is inserted
 /// instead (typically `"-"` if the word was hyphenated).
@@ -195,7 +195,7 @@ pub fn display_width(text: &str) -> usize {
 /// For wrapping purposes, the precise content of the word, the
 /// whitespace, and the penalty is irrelevant. All we need to know is
 /// the displayed width of each part, which this trait provides.
-pub trait Fragment: std::fmt::Debug {
+pub trait MeasuredFragment: std::fmt::Debug {
     /// Displayed width of word represented by this fragment.
     fn width(&self) -> usize;
 
@@ -210,8 +210,8 @@ pub trait Fragment: std::fmt::Debug {
 
 /// A piece of wrappable text, including any trailing whitespace.
 ///
-/// A `Word` is an example of a [`Fragment`], so it has a width,
-/// trailing whitespace, and potentially a penalty item.
+/// A `Word` is an example of a [`MeasuredFragment`], so it has a
+/// width, trailing whitespace, and potentially a penalty item.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct Word<'a> {
     /// Word content.
@@ -302,7 +302,7 @@ impl<'a> Word<'a> {
     }
 }
 
-impl Fragment for Word<'_> {
+impl MeasuredFragment for Word<'_> {
     #[inline]
     fn width(&self) -> usize {
         self.width

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,8 +149,8 @@
 //!
 //!   This feature can be disabled if you only need to wrap ASCII
 //!   text, or if the functions in [`core`] are used directly with
-//!   [`core::Fragment`]s for which the widths have been computed in
-//!   other ways.
+//!   [`core::MeasuredFragment`]s for which the widths have been
+//!   computed in other ways.
 //!
 //! * `smawk`: enables linear-time wrapping of the whole paragraph via
 //!   the [smawk] crate. See the [`wrap_algorithms::wrap_optimal_fit`]

--- a/src/wrap_algorithms.rs
+++ b/src/wrap_algorithms.rs
@@ -1,13 +1,13 @@
 //! Word wrapping algorithms.
 //!
-//! After a text has been broken into words (or [`Fragment`]s), one
-//! now has to decide how to break the fragments into lines. The
-//! simplest algorithm for this is implemented by [`wrap_first_fit`]:
-//! it uses no look-ahead and simply adds fragments to the line as
-//! long as they fit. However, this can lead to poor line breaks if a
-//! large fragment almost-but-not-quite fits on a line. When that
-//! happens, the fragment is moved to the next line and it will leave
-//! behind a large gap. A more advanced algorithm, implemented by
+//! After a text has been broken into smaller fragments, one now has
+//! to decide how to break the fragments into lines. The simplest
+//! algorithm for this is implemented by [`wrap_first_fit`]: it uses
+//! no look-ahead and simply adds fragments to the line as long as
+//! they fit. However, this can lead to poor line breaks if a large
+//! fragment almost-but-not-quite fits on a line. When that happens,
+//! the fragment is moved to the next line and it will leave behind a
+//! large gap. A more advanced algorithm, implemented by
 //! [`wrap_optimal_fit`], will take this into account. The optimal-fit
 //! algorithm considers all possible line breaks and will attempt to
 //! minimize the gaps left behind by overly short lines.
@@ -20,7 +20,7 @@ mod optimal_fit;
 #[cfg(feature = "smawk")]
 pub use optimal_fit::{wrap_optimal_fit, OptimalFit};
 
-use crate::core::{Fragment, Word};
+use crate::core::{MeasuredFragment, Word};
 
 /// Describes how to wrap words into lines.
 ///
@@ -173,7 +173,7 @@ impl WrapAlgorithm for FirstFit {
 ///
 /// ```
 /// use textwrap::wrap_algorithms::wrap_first_fit;
-/// use textwrap::core::{Fragment, Word};
+/// use textwrap::core::{MeasuredFragment, Word};
 ///
 /// #[derive(Debug)]
 /// struct Task<'a> {
@@ -183,7 +183,7 @@ impl WrapAlgorithm for FirstFit {
 ///     cleanup: usize, // Time needed for full cleanup if day ends with this task.
 /// }
 ///
-/// impl Fragment for Task<'_> {
+/// impl MeasuredFragment for Task<'_> {
 ///     fn width(&self) -> usize { self.hours }
 ///     fn whitespace_width(&self) -> usize { self.sweep }
 ///     fn penalty_width(&self) -> usize { self.cleanup }
@@ -245,7 +245,7 @@ impl WrapAlgorithm for FirstFit {
 ///
 /// Apologies to anyone who actually knows how to build a house and
 /// knows how long each step takes :-)
-pub fn wrap_first_fit<'a, 'b, T: Fragment>(
+pub fn wrap_first_fit<'a, 'b, T: MeasuredFragment>(
     fragments: &'a [T],
     line_widths: &'b [usize],
 ) -> Vec<&'a [T]> {

--- a/src/wrap_algorithms/optimal_fit.rs
+++ b/src/wrap_algorithms/optimal_fit.rs
@@ -1,6 +1,6 @@
 use std::cell::RefCell;
 
-use crate::core::{Fragment, Word};
+use crate::core::{MeasuredFragment, Word};
 use crate::wrap_algorithms::WrapAlgorithm;
 
 /// Wrap words using an advanced algorithm with look-ahead.
@@ -266,7 +266,7 @@ impl LineNumbers {
 ///
 /// **Note:** Only available when the `smawk` Cargo feature is
 /// enabled.
-pub fn wrap_optimal_fit<'a, 'b, T: Fragment>(
+pub fn wrap_optimal_fit<'a, 'b, T: MeasuredFragment>(
     fragments: &'a [T],
     line_widths: &'b [usize],
     penalties: &'b OptimalFit,


### PR DESCRIPTION
This name better matches the new `SplittableFragment` trait in #402.