### PR TITLE
Add checks for README examples and fix typo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ criterion = "0.3"
 lipsum = "0.8"
 unic-emoji-char = "0.9.0"
 version-sync = "0.9"
+doc-comment = "0.3"
 
 [target.'cfg(unix)'.dev-dependencies]
 termion = "1.5"

--- a/README.md
+++ b/README.md
@@ -79,13 +79,13 @@ Your program must load the hyphenation pattern and configure
 
 ```rust
 use hyphenation::{Language, Load, Standard};
-use textwrap::Options;
+use textwrap::{fill, Options};
 
 fn main() {
     let hyphenator = Standard::from_embedded(Language::EnglishUS).unwrap();
     let options = Options::new(28).word_splitter(hyphenator);
     let text = "textwrap: an efficient and powerful library for wrapping text.";
-    println!("{}", fill(text, &options);
+    println!("{}", fill(text, &options));
 }
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,6 +184,9 @@
 #![deny(missing_debug_implementations)]
 #![allow(clippy::redundant_field_names)]
 
+#[cfg(all(doctest, feature = "hyphenation"))]
+doc_comment::doctest!("../README.md");
+
 use std::borrow::Cow;
 
 mod indentation;


### PR DESCRIPTION
You had a small typo in one of your examples, so I fixed it and added a check for it. I added the `doc-comment` dependency as a dev-dependency.