### PR TITLE
Wrap README doctest in separate module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,7 +185,9 @@
 #![allow(clippy::redundant_field_names)]
 
 #[cfg(all(doctest, feature = "hyphenation"))]
-doc_comment::doctest!("../README.md");
+mod readme_doctest {
+    doc_comment::doctest!("../README.md");
+}
 
 use std::borrow::Cow;
 


### PR DESCRIPTION
We’ve gotten doctests for the README in #407. This PR changes the output on test failures from

    test src/lib.rs - (line 267) ... FAILED

to

    test src/lib.rs - readme_doctest (line 268) ... FAILED

which is slightly more informative. The line numbers are still off since I imagine they’re a combination of the line number in `lib.rs` and `README.md`. However, at least we now have an indication of where the error comes from. Finding the broken example should be easy then.