### PR TITLE
Cleanup needless borrows

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -241,7 +241,7 @@ impl<'a> Word<'a> {
         let trimmed = word.trim_end_matches(' ');
         Word {
             word: trimmed,
-            width: display_width(&trimmed),
+            width: display_width(trimmed),
             whitespace: &word[trimmed.len()..],
             penalty: "",
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -674,7 +674,7 @@ where
         if i > 0 {
             result.push('\n');
         }
-        result.push_str(&line);
+        result.push_str(line);
     }
 
     result
@@ -1091,7 +1091,7 @@ where
             result += &line[idx..idx + len];
 
             if !last_word.penalty.is_empty() {
-                result.to_mut().push_str(&last_word.penalty);
+                result.to_mut().push_str(last_word.penalty);
             }
 
             lines.push(result);
@@ -1199,8 +1199,8 @@ where
         for column_no in 0..columns {
             match wrapped_lines.get(line_no + column_no * lines_per_column) {
                 Some(column_line) => {
-                    line.push_str(&column_line);
-                    line.push_str(&" ".repeat(column_width - core::display_width(&column_line)));
+                    line.push_str(column_line);
+                    line.push_str(&" ".repeat(column_width - core::display_width(column_line)));
                 }
                 None => {
                     line.push_str(&" ".repeat(column_width));

--- a/src/word_separators.rs
+++ b/src/word_separators.rs
@@ -212,7 +212,7 @@ impl WordSeparator for UnicodeBreakProperties {
             None => None,
         });
 
-        let stripped = strip_ansi_escape_sequences(&line);
+        let stripped = strip_ansi_escape_sequences(line);
         let mut opportunities = unicode_linebreak::linebreaks(&stripped)
             .filter(|(idx, _)| {
                 #[allow(clippy::match_like_matches_macro)]

--- a/src/wrap_algorithms/optimal_fit.rs
+++ b/src/wrap_algorithms/optimal_fit.rs
@@ -161,7 +161,7 @@ impl Default for OptimalFit {
 impl WrapAlgorithm for OptimalFit {
     #[inline]
     fn wrap<'a, 'b>(&self, words: &'b [Word<'a>], line_widths: &'b [usize]) -> Vec<&'b [Word<'a>]> {
-        wrap_optimal_fit(words, line_widths, &self)
+        wrap_optimal_fit(words, line_widths, self)
     }
 }
 
@@ -183,7 +183,7 @@ impl LineNumbers {
     fn get<T>(&self, i: usize, minima: &[(usize, T)]) -> usize {
         while self.line_numbers.borrow_mut().len() < i + 1 {
             let pos = self.line_numbers.borrow().len();
-            let line_number = 1 + self.get(minima[pos].0, &minima);
+            let line_number = 1 + self.get(minima[pos].0, minima);
             self.line_numbers.borrow_mut().push(line_number);
         }
 
@@ -285,7 +285,7 @@ pub fn wrap_optimal_fit<'a, 'b, T: Fragment>(
 
     let minima = smawk::online_column_minima(0, widths.len(), |minima, i, j| {
         // Line number for fragment `i`.
-        let line_number = line_numbers.get(i, &minima);
+        let line_number = line_numbers.get(i, minima);
         let line_width = line_widths
             .get(line_number)
             .copied()


### PR DESCRIPTION
This simply fixes a bunch of

> warning: this expression borrows a reference that is immediately dereferenced by the compiler

warnings from Clippy.