### PR TITLE
Use `u16` instead of `usize` for line width

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,11 +134,17 @@ jobs:
       - name: Build fuzz targets
         run: cargo fuzz build
 
-      - name: Fuzz test
+      - name: Fuzz test fill_first_fit
         run: cargo fuzz run fill_first_fit -- -max_total_time=30
 
-      - name: Minimize fuzz corpus
+      - name: Fuzz test fill_optimal_fit
+        run: cargo fuzz run fill_optimal_fit -- -max_total_time=30
+
+      - name: Minimize fill_first_fit corpus
         run: cargo fuzz cmin fill_first_fit
+
+      - name: Minimize fill_optimal_fit corpus
+        run: cargo fuzz cmin fill_optimal_fit
 
   binary-sizes:
     name: Compute binary sizes

--- a/benches/linear.rs
+++ b/benches/linear.rs
@@ -9,7 +9,7 @@ use criterion::{criterion_group, criterion_main};
 
 use lipsum::lipsum_words_from_seed;
 
-const LINE_LENGTH: usize = 60;
+const LINE_LENGTH: u16 = 60;
 
 /// Generate a lorem ipsum text with the given number of characters.
 fn lorem_ipsum(length: usize) -> String {

--- a/benches/linear.rs
+++ b/benches/linear.rs
@@ -9,7 +9,7 @@ use criterion::{criterion_group, criterion_main};
 
 use lipsum::lipsum_words_from_seed;
 
-const LINE_LENGTH: u16 = 60;
+const LINE_LENGTH: u32 = 60;
 
 /// Generate a lorem ipsum text with the given number of characters.
 fn lorem_ipsum(length: usize) -> String {

--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -7,7 +7,8 @@ fn main() {
                    Zero-cost abstractions.";
     let mut prev_lines = vec![];
 
-    let mut options = Options::new(0).word_splitter(Box::new(HyphenSplitter) as Box<dyn WordSplitter>);
+    let mut options =
+        Options::new(0).word_splitter(Box::new(HyphenSplitter) as Box<dyn WordSplitter>);
     #[cfg(feature = "hyphenation")]
     {
         use hyphenation::Load;
@@ -21,9 +22,9 @@ fn main() {
         let lines = wrap(example, &options);
         if lines != prev_lines {
             let title = format!(" Width: {} ", width);
-            println!(".{:-^1$}.", title, width + 2);
+            println!(".{:-^1$}.", title, (width + 2).into());
             for line in &lines {
-                println!("| {:1$} |", line, width);
+                println!("| {:1$} |", line, width.into());
             }
             prev_lines = lines;
         }

--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -22,9 +22,9 @@ fn main() {
         let lines = wrap(example, &options);
         if lines != prev_lines {
             let title = format!(" Width: {} ", width);
-            println!(".{:-^1$}.", title, (width + 2).into());
+            println!(".{:-^1$}.", title, width as usize + 2);
             for line in &lines {
-                println!("| {:1$} |", line, width.into());
+                println!("| {:1$} |", line, width as usize);
             }
             prev_lines = lines;
         }

--- a/examples/wasm/src/lib.rs
+++ b/examples/wasm/src/lib.rs
@@ -145,22 +145,22 @@ impl<'a> CanvasWord<'a> {
     }
 }
 
-const PRECISION: usize = 10;
+const PRECISION: u16 = 10;
 
 impl textwrap::core::Fragment for CanvasWord<'_> {
     #[inline]
-    fn width(&self) -> usize {
-        (self.width * PRECISION as f64) as usize
+    fn width(&self) -> u16 {
+        (self.width * PRECISION as f64) as u16
     }
 
     #[inline]
-    fn whitespace_width(&self) -> usize {
-        (self.whitespace_width * PRECISION as f64) as usize
+    fn whitespace_width(&self) -> u16 {
+        (self.whitespace_width * PRECISION as f64) as u16
     }
 
     #[inline]
-    fn penalty_width(&self) -> usize {
-        (self.penalty_width * PRECISION as f64) as usize
+    fn penalty_width(&self) -> u16 {
+        (self.penalty_width * PRECISION as f64) as u16
     }
 }
 
@@ -250,22 +250,22 @@ pub enum WasmWrapAlgorithm {
 #[wasm_bindgen]
 #[derive(Copy, Clone, Debug, Default)]
 pub struct WasmOptimalFit {
-    pub nline_penalty: i32,
-    pub overflow_penalty: i32,
-    pub short_last_line_fraction: usize,
-    pub short_last_line_penalty: i32,
-    pub hyphen_penalty: i32,
+    pub nline_penalty: u32,
+    pub overflow_penalty: u32,
+    pub short_last_line_fraction: u32,
+    pub short_last_line_penalty: u32,
+    pub hyphen_penalty: u32,
 }
 
 #[wasm_bindgen]
 impl WasmOptimalFit {
     #[wasm_bindgen(constructor)]
     pub fn new(
-        nline_penalty: i32,
-        overflow_penalty: i32,
-        short_last_line_fraction: usize,
-        short_last_line_penalty: i32,
-        hyphen_penalty: i32,
+        nline_penalty: u32,
+        overflow_penalty: u32,
+        short_last_line_fraction: u32,
+        short_last_line_penalty: u32,
+        hyphen_penalty: u32,
     ) -> WasmOptimalFit {
         WasmOptimalFit {
             nline_penalty,
@@ -292,7 +292,7 @@ impl Into<OptimalFit> for WasmOptimalFit {
 #[wasm_bindgen]
 #[derive(Copy, Clone, Debug)]
 pub struct WasmOptions {
-    pub width: usize,
+    pub width: u16,
     pub break_words: bool,
     pub word_separator: WasmWordSeparator,
     pub word_splitter: WasmWordSplitter,
@@ -304,7 +304,7 @@ pub struct WasmOptions {
 impl WasmOptions {
     #[wasm_bindgen(constructor)]
     pub fn new(
-        width: usize,
+        width: u16,
         break_words: bool,
         word_separator: WasmWordSeparator,
         word_splitter: WasmWordSplitter,

--- a/examples/wasm/src/lib.rs
+++ b/examples/wasm/src/lib.rs
@@ -145,22 +145,22 @@ impl<'a> CanvasWord<'a> {
     }
 }
 
-const PRECISION: u16 = 10;
+const PRECISION: u32 = 10;
 
 impl textwrap::core::Fragment for CanvasWord<'_> {
     #[inline]
-    fn width(&self) -> u16 {
-        (self.width * PRECISION as f64) as u16
+    fn width(&self) -> u32 {
+        (self.width * PRECISION as f64) as u32
     }
 
     #[inline]
-    fn whitespace_width(&self) -> u16 {
-        (self.whitespace_width * PRECISION as f64) as u16
+    fn whitespace_width(&self) -> u32 {
+        (self.whitespace_width * PRECISION as f64) as u32
     }
 
     #[inline]
-    fn penalty_width(&self) -> u16 {
-        (self.penalty_width * PRECISION as f64) as u16
+    fn penalty_width(&self) -> u32 {
+        (self.penalty_width * PRECISION as f64) as u32
     }
 }
 
@@ -292,7 +292,7 @@ impl Into<OptimalFit> for WasmOptimalFit {
 #[wasm_bindgen]
 #[derive(Copy, Clone, Debug)]
 pub struct WasmOptions {
-    pub width: u16,
+    pub width: u32,
     pub break_words: bool,
     pub word_separator: WasmWordSeparator,
     pub word_splitter: WasmWordSplitter,
@@ -304,7 +304,7 @@ pub struct WasmOptions {
 impl WasmOptions {
     #[wasm_bindgen(constructor)]
     pub fn new(
-        width: u16,
+        width: u32,
         break_words: bool,
         word_separator: WasmWordSeparator,
         word_splitter: WasmWordSplitter,

--- a/examples/wasm/www/index.html
+++ b/examples/wasm/www/index.html
@@ -97,7 +97,7 @@ You can test the word-wrapping behavior by editing the text 😍✨</textarea>
       <div class="option">
         <label for="overflow-penalty">Overflow penalty:</label>
         <input type="number" id="overflow-penalty-text">
-        <input type="range" id="overflow-penalty" min="-1000" max="10000" value="7500">
+        <input type="range" id="overflow-penalty" min="0" max="10000" value="7500">
       </div>
 
       <div class="option">
@@ -109,13 +109,13 @@ You can test the word-wrapping behavior by editing the text 😍✨</textarea>
       <div class="option">
         <label for="short-last-line-penalty">Short line penalty:</label>
         <input type="number" id="short-last-line-penalty-text">
-        <input type="range" id="short-last-line-penalty" min="-2000" max="2000" value="100">
+        <input type="range" id="short-last-line-penalty" min="0" max="2000" value="100">
       </div>
 
       <div class="option">
         <label for="hyphen-penalty">Hyphen penalty:</label>
         <input type="number" id="hyphen-penalty-text">
-        <input type="range" id="hyphen-penalty" min="-2000" max="2000" value="100">
+        <input type="range" id="hyphen-penalty" min="0" max="2000" value="100">
       </div>
     </div>
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,12 +10,25 @@ edition = "2018"
 cargo-fuzz = true
 
 [dependencies]
-libfuzzer-sys = "0.3"
+arbitrary = { version = "1", features = ["derive"] }
+libfuzzer-sys = "0.4"
 textwrap = { path = ".." }
 
 # Prevent this from interfering with workspaces
 [workspace]
 members = ["."]
+
+[[bin]]
+name = "fill_first_fit"
+path = "fuzz_targets/fill_first_fit.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "wrap_first_fit"
+path = "fuzz_targets/wrap_first_fit.rs"
+test = false
+doc = false
 
 [[bin]]
 name = "fill_optimal_fit"
@@ -24,7 +37,7 @@ test = false
 doc = false
 
 [[bin]]
-name = "fill_first_fit"
-path = "fuzz_targets/fill_first_fit.rs"
+name = "wrap_optimal_fit"
+path = "fuzz_targets/wrap_optimal_fit.rs"
 test = false
 doc = false

--- a/fuzz/fuzz_targets/fill_first_fit.rs
+++ b/fuzz/fuzz_targets/fill_first_fit.rs
@@ -3,7 +3,7 @@ use libfuzzer_sys::fuzz_target;
 use textwrap::wrap_algorithms;
 use textwrap::Options;
 
-fuzz_target!(|input: (String, u16)| {
+fuzz_target!(|input: (String, u32)| {
     let options = Options::new(input.1).wrap_algorithm(wrap_algorithms::FirstFit);
     let _ = textwrap::fill(&input.0, &options);
 });

--- a/fuzz/fuzz_targets/fill_first_fit.rs
+++ b/fuzz/fuzz_targets/fill_first_fit.rs
@@ -3,7 +3,7 @@ use libfuzzer_sys::fuzz_target;
 use textwrap::wrap_algorithms;
 use textwrap::Options;
 
-fuzz_target!(|input: (String, usize)| {
+fuzz_target!(|input: (String, u16)| {
     let options = Options::new(input.1).wrap_algorithm(wrap_algorithms::FirstFit);
     let _ = textwrap::fill(&input.0, &options);
 });

--- a/fuzz/fuzz_targets/fill_optimal_fit.rs
+++ b/fuzz/fuzz_targets/fill_optimal_fit.rs
@@ -3,7 +3,7 @@ use libfuzzer_sys::fuzz_target;
 use textwrap::wrap_algorithms;
 use textwrap::Options;
 
-fuzz_target!(|input: (String, u16)| {
+fuzz_target!(|input: (String, u32)| {
     let options = Options::new(input.1).wrap_algorithm(wrap_algorithms::OptimalFit::default());
     let _ = textwrap::fill(&input.0, &options);
 });

--- a/fuzz/fuzz_targets/fill_optimal_fit.rs
+++ b/fuzz/fuzz_targets/fill_optimal_fit.rs
@@ -3,7 +3,7 @@ use libfuzzer_sys::fuzz_target;
 use textwrap::wrap_algorithms;
 use textwrap::Options;
 
-fuzz_target!(|input: (String, usize)| {
+fuzz_target!(|input: (String, u16)| {
     let options = Options::new(input.1).wrap_algorithm(wrap_algorithms::OptimalFit::default());
     let _ = textwrap::fill(&input.0, &options);
 });

--- a/fuzz/fuzz_targets/wrap_first_fit.rs
+++ b/fuzz/fuzz_targets/wrap_first_fit.rs
@@ -1,0 +1,25 @@
+#![no_main]
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+use textwrap::core;
+use textwrap::wrap_algorithms::wrap_first_fit;
+
+#[derive(Arbitrary, Debug, Eq, PartialEq)]
+struct Word {
+    width: u16,
+    whitespace_width: u16,
+    penalty_width: u16,
+}
+
+#[rustfmt::skip]
+impl core::Fragment for Word {
+    fn width(&self) -> u16 { self.width }
+    fn whitespace_width(&self) -> u16 { self.whitespace_width }
+    fn penalty_width(&self) -> u16 { self.penalty_width }
+}
+
+fuzz_target!(|input: (u16, Vec<Word>)| {
+    let width = input.0;
+    let words = input.1;
+    let _ = wrap_first_fit(&words, &[width]);
+});

--- a/fuzz/fuzz_targets/wrap_first_fit.rs
+++ b/fuzz/fuzz_targets/wrap_first_fit.rs
@@ -6,19 +6,19 @@ use textwrap::wrap_algorithms::wrap_first_fit;
 
 #[derive(Arbitrary, Debug, Eq, PartialEq)]
 struct Word {
-    width: u16,
-    whitespace_width: u16,
-    penalty_width: u16,
+    width: u32,
+    whitespace_width: u32,
+    penalty_width: u32,
 }
 
 #[rustfmt::skip]
 impl core::Fragment for Word {
-    fn width(&self) -> u16 { self.width }
-    fn whitespace_width(&self) -> u16 { self.whitespace_width }
-    fn penalty_width(&self) -> u16 { self.penalty_width }
+    fn width(&self) -> u32 { self.width }
+    fn whitespace_width(&self) -> u32 { self.whitespace_width }
+    fn penalty_width(&self) -> u32 { self.penalty_width }
 }
 
-fuzz_target!(|input: (u16, Vec<Word>)| {
+fuzz_target!(|input: (u32, Vec<Word>)| {
     let width = input.0;
     let words = input.1;
     let _ = wrap_first_fit(&words, &[width]);

--- a/fuzz/fuzz_targets/wrap_optimal_fit.rs
+++ b/fuzz/fuzz_targets/wrap_optimal_fit.rs
@@ -1,0 +1,47 @@
+#![no_main]
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+use textwrap::core;
+use textwrap::wrap_algorithms::{wrap_optimal_fit, OptimalFit};
+
+#[derive(Arbitrary, Debug)]
+struct Penalties {
+    nline_penalty: u32,
+    overflow_penalty: u32,
+    short_last_line_fraction: u32,
+    short_last_line_penalty: u32,
+    hyphen_penalty: u32,
+}
+
+impl Into<OptimalFit> for Penalties {
+    fn into(self) -> OptimalFit {
+        OptimalFit {
+            nline_penalty: self.nline_penalty,
+            overflow_penalty: self.overflow_penalty,
+            short_last_line_fraction: std::cmp::max(1, self.short_last_line_fraction),
+            short_last_line_penalty: self.short_last_line_penalty,
+            hyphen_penalty: self.hyphen_penalty,
+        }
+    }
+}
+
+#[derive(Arbitrary, Debug, Eq, PartialEq)]
+struct Word {
+    width: u16,
+    whitespace_width: u16,
+    penalty_width: u16,
+}
+
+#[rustfmt::skip]
+impl core::Fragment for Word {
+    fn width(&self) -> u16 { self.width }
+    fn whitespace_width(&self) -> u16 { self.whitespace_width }
+    fn penalty_width(&self) -> u16 { self.penalty_width }
+}
+
+fuzz_target!(|input: (u16, Vec<Word>, Penalties)| {
+    let width = input.0;
+    let words = input.1;
+    let penalties = input.2.into();
+    let _ = wrap_optimal_fit(&words, &[width], &penalties);
+});

--- a/fuzz/fuzz_targets/wrap_optimal_fit.rs
+++ b/fuzz/fuzz_targets/wrap_optimal_fit.rs
@@ -27,19 +27,19 @@ impl Into<OptimalFit> for Penalties {
 
 #[derive(Arbitrary, Debug, Eq, PartialEq)]
 struct Word {
-    width: u16,
-    whitespace_width: u16,
-    penalty_width: u16,
+    width: u32,
+    whitespace_width: u32,
+    penalty_width: u32,
 }
 
 #[rustfmt::skip]
 impl core::Fragment for Word {
-    fn width(&self) -> u16 { self.width }
-    fn whitespace_width(&self) -> u16 { self.whitespace_width }
-    fn penalty_width(&self) -> u16 { self.penalty_width }
+    fn width(&self) -> u32 { self.width }
+    fn whitespace_width(&self) -> u32 { self.whitespace_width }
+    fn penalty_width(&self) -> u32 { self.penalty_width }
 }
 
-fuzz_target!(|input: (u16, Vec<Word>, Penalties)| {
+fuzz_target!(|input: (u32, Vec<Word>, Penalties)| {
     let width = input.0;
     let words = input.1;
     let penalties = input.2.into();

--- a/src/core.rs
+++ b/src/core.rs
@@ -35,6 +35,8 @@
 //! the functionality here is not sufficient or if you have ideas for
 //! improving it. We would love to hear from you!
 
+use std::convert::TryInto;
+
 /// The CSI or “Control Sequence Introducer” introduces an ANSI escape
 /// sequence. This is typically used for colored text and will be
 /// ignored when computing the text width.
@@ -62,8 +64,10 @@ pub(crate) fn skip_ansi_escape_sequence<I: Iterator<Item = char>>(ch: char, char
 
 #[cfg(feature = "unicode-width")]
 #[inline]
-fn ch_width(ch: char) -> usize {
-    unicode_width::UnicodeWidthChar::width(ch).unwrap_or(0)
+fn ch_width(ch: char) -> u16 {
+    unicode_width::UnicodeWidthChar::width(ch)
+        .and_then(|w| w.try_into().ok())
+        .unwrap_or(0)
 }
 
 /// First character which [`ch_width`] will classify as double-width.
@@ -73,7 +77,7 @@ const DOUBLE_WIDTH_CUTOFF: char = '\u{1100}';
 
 #[cfg(not(feature = "unicode-width"))]
 #[inline]
-fn ch_width(ch: char) -> usize {
+fn ch_width(ch: char) -> u16 {
     if ch < DOUBLE_WIDTH_CUTOFF {
         1
     } else {
@@ -173,7 +177,7 @@ fn ch_width(ch: char) -> usize {
 /// [Unicode equivalence]: https://en.wikipedia.org/wiki/Unicode_equivalence
 /// [CJK characters]: https://en.wikipedia.org/wiki/CJK_characters
 /// [emoji modifier sequences]: https://unicode.org/emoji/charts/full-emoji-modifiers.html
-pub fn display_width(text: &str) -> usize {
+pub fn display_width(text: &str) -> u16 {
     let mut chars = text.chars();
     let mut width = 0;
     while let Some(ch) = chars.next() {
@@ -197,15 +201,15 @@ pub fn display_width(text: &str) -> usize {
 /// the displayed width of each part, which this trait provides.
 pub trait Fragment: std::fmt::Debug {
     /// Displayed width of word represented by this fragment.
-    fn width(&self) -> usize;
+    fn width(&self) -> u16;
 
     /// Displayed width of the whitespace that must follow the word
     /// when the word is not at the end of a line.
-    fn whitespace_width(&self) -> usize;
+    fn whitespace_width(&self) -> u16;
 
     /// Displayed width of the penalty that must be inserted if the
     /// word falls at the end of a line.
-    fn penalty_width(&self) -> usize;
+    fn penalty_width(&self) -> u16;
 }
 
 /// A piece of wrappable text, including any trailing whitespace.
@@ -221,7 +225,7 @@ pub struct Word<'a> {
     /// Penalty string to insert if the word falls at the end of a line.
     pub penalty: &'a str,
     // Cached width in columns.
-    pub(crate) width: usize,
+    pub(crate) width: u16,
 }
 
 impl std::ops::Deref for Word<'_> {
@@ -260,7 +264,7 @@ impl<'a> Word<'a> {
     ///     vec![Word::from("Hel"), Word::from("lo!  ")]
     /// );
     /// ```
-    pub fn break_apart<'b>(&'b self, line_width: usize) -> impl Iterator<Item = Word<'a>> + 'b {
+    pub fn break_apart<'b>(&'b self, line_width: u16) -> impl Iterator<Item = Word<'a>> + 'b {
         let mut char_indices = self.word.char_indices();
         let mut offset = 0;
         let mut width = 0;
@@ -304,22 +308,22 @@ impl<'a> Word<'a> {
 
 impl Fragment for Word<'_> {
     #[inline]
-    fn width(&self) -> usize {
+    fn width(&self) -> u16 {
         self.width
     }
 
     // We assume the whitespace consist of ' ' only. This allows us to
     // compute the display width in constant time.
     #[inline]
-    fn whitespace_width(&self) -> usize {
-        self.whitespace.len()
+    fn whitespace_width(&self) -> u16 {
+        self.whitespace.len().try_into().expect("Width exceeds u16")
     }
 
     // We assume the penalty is `""` or `"-"`. This allows us to
     // compute the display width in constant time.
     #[inline]
-    fn penalty_width(&self) -> usize {
-        self.penalty.len()
+    fn penalty_width(&self) -> u16 {
+        self.penalty.len().try_into().expect("Width exceeds u16")
     }
 }
 
@@ -328,7 +332,7 @@ impl Fragment for Word<'_> {
 /// This simply calls [`Word::break_apart`] on words that are too
 /// wide. This means that no extra `'-'` is inserted, the word is
 /// simply broken into smaller pieces.
-pub fn break_words<'a, I>(words: I, line_width: usize) -> Vec<Word<'a>>
+pub fn break_words<'a, I>(words: I, line_width: u16) -> Vec<Word<'a>>
 where
     I: IntoIterator<Item = Word<'a>>,
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -262,7 +262,7 @@ pub struct Options<
     WordSplit = Box<dyn word_splitters::WordSplitter>,
 > {
     /// The width in columns at which the text will be wrapped.
-    pub width: usize,
+    pub width: u16,
     /// Indentation used for the first line of output. See the
     /// [`Options::initial_indent`] method.
     pub initial_indent: &'a str,
@@ -307,7 +307,7 @@ where
     }
 }
 
-impl<'a> From<usize>
+impl<'a> From<u16>
     for Options<
         'a,
         DefaultWrapAlgorithm!(),
@@ -315,7 +315,7 @@ impl<'a> From<usize>
         word_splitters::HyphenSplitter,
     >
 {
-    fn from(width: usize) -> Self {
+    fn from(width: u16) -> Self {
         Options::new(width)
     }
 }
@@ -356,7 +356,7 @@ impl<'a>
     /// Note that the default word separator and wrap algorithms
     /// changes based on the available Cargo features. The best
     /// available algorithms are used by default.
-    pub const fn new(width: usize) -> Self {
+    pub const fn new(width: u16) -> Self {
         Options::with_word_splitter(width, word_splitters::HyphenSplitter)
     }
 
@@ -391,7 +391,7 @@ impl<'a, WordSplit> Options<'a, DefaultWrapAlgorithm!(), DefaultWordSeparator!()
     /// # use textwrap::Options;
     /// # use textwrap::word_splitters::{NoHyphenation, HyphenSplitter};
     /// # const word_splitter: NoHyphenation = NoHyphenation;
-    /// # const width: usize = 80;
+    /// # const width: u16 = 80;
     /// # let actual = Options::with_word_splitter(width, word_splitter);
     /// # let expected =
     /// Options::new(width).word_splitter(word_splitter)
@@ -410,7 +410,7 @@ impl<'a, WordSplit> Options<'a, DefaultWrapAlgorithm!(), DefaultWordSeparator!()
     /// ```
     /// use textwrap::Options;
     /// use textwrap::word_splitters::{HyphenSplitter, NoHyphenation, WordSplitter};
-    /// # const width: usize = 80;
+    /// # const width: u16 = 80;
     ///
     /// // The type annotation is important, otherwise it will be not a trait object
     /// let mut options: Options<_, _, Box<dyn WordSplitter>>
@@ -434,7 +434,7 @@ impl<'a, WordSplit> Options<'a, DefaultWrapAlgorithm!(), DefaultWordSeparator!()
     /// use textwrap::word_splitters::HyphenSplitter;
     /// use textwrap::word_separators::AsciiSpace;
     /// use textwrap::wrap_algorithms::FirstFit;
-    /// # const width: usize = 80;
+    /// # const width: u16 = 80;
     ///
     /// # #[cfg(all(not(feature = "smawk"), not(feature = "unicode-linebreak")))] {
     /// const FOO: Options<FirstFit, AsciiSpace, HyphenSplitter> =
@@ -442,7 +442,7 @@ impl<'a, WordSplit> Options<'a, DefaultWrapAlgorithm!(), DefaultWordSeparator!()
     /// static BAR: Options<FirstFit, AsciiSpace, HyphenSplitter> = FOO;
     /// # }
     /// ```
-    pub const fn with_word_splitter(width: usize, word_splitter: WordSplit) -> Self {
+    pub const fn with_word_splitter(width: u16, word_splitter: WordSplit) -> Self {
         Options {
             width,
             initial_indent: "",
@@ -645,8 +645,8 @@ impl<'a, WrapAlgo, WordSep, WordSplit> Options<'a, WrapAlgo, WordSep, WordSplit>
 /// **Note:** Only available when the `terminal_size` Cargo feature is
 /// enabled.
 #[cfg(feature = "terminal_size")]
-pub fn termwidth() -> usize {
-    terminal_size::terminal_size().map_or(80, |(terminal_size::Width(w), _)| w.into())
+pub fn termwidth() -> u16 {
+    terminal_size::terminal_size().map_or(80, |(terminal_size::Width(w), _)| w)
 }
 
 /// Fill a line of text at a given width.
@@ -1200,6 +1200,7 @@ where
     Opt: Into<Options<'a, WrapAlgo, WordSep, WordSplit>>,
 {
     assert!(columns > 0);
+    assert!(columns < u16::max_value().into());
 
     let mut options = total_width_or_options.into();
 
@@ -1207,11 +1208,11 @@ where
         .width
         .saturating_sub(core::display_width(left_gap))
         .saturating_sub(core::display_width(right_gap))
-        .saturating_sub(core::display_width(middle_gap) * (columns - 1));
+        .saturating_sub(core::display_width(middle_gap) * (columns as u16 - 1));
 
-    let column_width = std::cmp::max(inner_width / columns, 1);
-    options.width = column_width;
-    let last_column_padding = " ".repeat(inner_width % column_width);
+    let column_width = std::cmp::max(inner_width as usize / columns, 1);
+    options.width = column_width as u16;
+    let last_column_padding = " ".repeat(inner_width as usize % column_width);
     let wrapped_lines = wrap(text, options);
     let lines_per_column =
         wrapped_lines.len() / columns + usize::from(wrapped_lines.len() % columns > 0);
@@ -1222,7 +1223,9 @@ where
             match wrapped_lines.get(line_no + column_no * lines_per_column) {
                 Some(column_line) => {
                     line.push_str(column_line);
-                    line.push_str(&" ".repeat(column_width - core::display_width(column_line)));
+                    line.push_str(
+                        &" ".repeat(column_width - core::display_width(column_line) as usize),
+                    );
                 }
                 None => {
                     line.push_str(&" ".repeat(column_width));
@@ -1295,7 +1298,7 @@ where
 /// Please see the [`linear`
 /// benchmark](https://github.com/mgeisler/textwrap/blob/master/benches/linear.rs)
 /// for details.
-pub fn fill_inplace(text: &mut String, width: usize) {
+pub fn fill_inplace(text: &mut String, width: u16) {
     use word_separators::WordSeparator;
     let mut indices = Vec::new();
 
@@ -1342,7 +1345,7 @@ mod tests {
 
     #[test]
     fn options_agree_with_usize() {
-        let opt_usize = Options::from(42_usize);
+        let opt_usize = Options::from(42_u16);
         let opt_options = Options::new(42);
 
         assert_eq!(opt_usize.width, opt_options.width);
@@ -1393,7 +1396,9 @@ mod tests {
 
     #[test]
     fn max_width() {
-        assert_eq!(wrap("foo bar", usize::max_value()), vec!["foo bar"]);
+        assert_eq!(wrap("foo bar", u16::max_value()), vec!["foo bar"]);
+        let long_text = "foobar baz foobar baz foobar baz foobar baz foobar baz";
+        assert_eq!(wrap(&long_text, u16::max_value()), vec![long_text]);
     }
 
     #[test]

--- a/src/wrap_algorithms.rs
+++ b/src/wrap_algorithms.rs
@@ -37,7 +37,7 @@ pub trait WrapAlgorithm: WrapAlgorithmClone + std::fmt::Debug {
     /// can be used to implement hanging indentation.
     ///
     /// Please see the implementors of the trait for examples.
-    fn wrap<'a, 'b>(&self, words: &'b [Word<'a>], line_widths: &'b [usize]) -> Vec<&'b [Word<'a>]>;
+    fn wrap<'a, 'b>(&self, words: &'b [Word<'a>], line_widths: &'b [u16]) -> Vec<&'b [Word<'a>]>;
 }
 
 // The internal `WrapAlgorithmClone` trait is allows us to implement
@@ -63,7 +63,7 @@ impl Clone for Box<dyn WrapAlgorithm> {
 }
 
 impl WrapAlgorithm for Box<dyn WrapAlgorithm> {
-    fn wrap<'a, 'b>(&self, words: &'b [Word<'a>], line_widths: &'b [usize]) -> Vec<&'b [Word<'a>]> {
+    fn wrap<'a, 'b>(&self, words: &'b [Word<'a>], line_widths: &'b [u16]) -> Vec<&'b [Word<'a>]> {
         use std::ops::Deref;
         self.deref().wrap(words, line_widths)
     }
@@ -92,7 +92,7 @@ impl Default for FirstFit {
 
 impl WrapAlgorithm for FirstFit {
     #[inline]
-    fn wrap<'a, 'b>(&self, words: &'b [Word<'a>], line_widths: &'b [usize]) -> Vec<&'b [Word<'a>]> {
+    fn wrap<'a, 'b>(&self, words: &'b [Word<'a>], line_widths: &'b [u16]) -> Vec<&'b [Word<'a>]> {
         wrap_first_fit(words, line_widths)
     }
 }
@@ -178,15 +178,15 @@ impl WrapAlgorithm for FirstFit {
 /// #[derive(Debug)]
 /// struct Task<'a> {
 ///     name: &'a str,
-///     hours: usize,   // Time needed to complete task.
-///     sweep: usize,   // Time needed for a quick sweep after task during the day.
-///     cleanup: usize, // Time needed for full cleanup if day ends with this task.
+///     hours: u16,   // Time needed to complete task.
+///     sweep: u16,   // Time needed for a quick sweep after task during the day.
+///     cleanup: u16, // Time needed for full cleanup if day ends with this task.
 /// }
 ///
 /// impl Fragment for Task<'_> {
-///     fn width(&self) -> usize { self.hours }
-///     fn whitespace_width(&self) -> usize { self.sweep }
-///     fn penalty_width(&self) -> usize { self.cleanup }
+///     fn width(&self) -> u16 { self.hours }
+///     fn whitespace_width(&self) -> u16 { self.sweep }
+///     fn penalty_width(&self) -> u16 { self.cleanup }
 /// }
 ///
 /// // The morning tasks
@@ -205,14 +205,14 @@ impl WrapAlgorithm for FirstFit {
 /// // Fill tasks into days, taking `day_length` into account. The
 /// // output shows the hours worked per day along with the names of
 /// // the tasks for that day.
-/// fn assign_days<'a>(tasks: &[Task<'a>], day_length: usize) -> Vec<(usize, Vec<&'a str>)> {
+/// fn assign_days<'a>(tasks: &[Task<'a>], day_length: u16) -> Vec<(u16, Vec<&'a str>)> {
 ///     let mut days = Vec::new();
 ///     // Assign tasks to days. The assignment is a vector of slices,
 ///     // with a slice per day.
 ///     let assigned_days: Vec<&[Task<'a>]> = wrap_first_fit(&tasks, &[day_length]);
 ///     for day in assigned_days.iter() {
 ///         let last = day.last().unwrap();
-///         let work_hours: usize = day.iter().map(|t| t.hours + t.sweep).sum();
+///         let work_hours: u16 = day.iter().map(|t| t.hours + t.sweep).sum();
 ///         let names = day.iter().map(|t| t.name).collect::<Vec<_>>();
 ///         days.push((work_hours - last.sweep + last.cleanup, names));
 ///     }
@@ -247,26 +247,65 @@ impl WrapAlgorithm for FirstFit {
 /// knows how long each step takes :-)
 pub fn wrap_first_fit<'a, 'b, T: Fragment>(
     fragments: &'a [T],
-    line_widths: &'b [usize],
+    line_widths: &'b [u16],
 ) -> Vec<&'a [T]> {
     // The final line width is used for all remaining lines.
     let default_line_width = line_widths.last().copied().unwrap_or(0);
     let mut lines = Vec::new();
     let mut start = 0;
-    let mut width = 0;
+    let mut width: u64 = 0;
 
     for (idx, fragment) in fragments.iter().enumerate() {
-        let line_width = line_widths
+        let line_width: u64 = line_widths
             .get(lines.len())
             .copied()
-            .unwrap_or(default_line_width);
-        if width + fragment.width() + fragment.penalty_width() > line_width && idx > start {
+            .unwrap_or(default_line_width)
+            .into();
+        if width + fragment.width() as u64 + fragment.penalty_width() as u64 > line_width
+            && idx > start
+        {
             lines.push(&fragments[start..idx]);
             start = idx;
             width = 0;
         }
-        width += fragment.width() + fragment.whitespace_width();
+        width += fragment.width() as u64 + fragment.whitespace_width() as u64;
     }
     lines.push(&fragments[start..]);
     lines
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, Eq, PartialEq)]
+    struct Word(u16);
+
+    #[rustfmt::skip]
+    impl Fragment for Word {
+        fn width(&self) -> u16 { self.0 }
+        fn whitespace_width(&self) -> u16 { 1 }
+        fn penalty_width(&self) -> u16 { 0 }
+    }
+
+    #[test]
+    fn wrap_string_longer_than_u16() {
+        let words = vec![
+            Word(10_000),
+            Word(20_000),
+            Word(30_000),
+            Word(40_000),
+            Word(50_000),
+        ];
+
+        assert_eq!(
+            wrap_first_fit(&words, &[45_000]),
+            &[
+                vec![Word(10_000), Word(20_000)],
+                vec![Word(30_000)],
+                vec![Word(40_000)],
+                vec![Word(50_000)],
+            ]
+        );
+    }
 }


### PR DESCRIPTION
Using an `usize` for the line width causes problems for the optimal-fit wrapping algorithm. The problem is that the algorithm works with integer values formed by

    (line_width - text_width)**2

When `line_width` is near `usize::max_value()`, this computation will overflow an `usize`. By limiting the line width to an `u16`, we can do the internal computations with `u64` and avoid the overflows.