### PR TITLE
Add fuzz tests with fully arbitrary fragments

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,12 +10,25 @@ edition = "2018"
 cargo-fuzz = true
 
 [dependencies]
-libfuzzer-sys = "0.3"
+arbitrary = { version = "1", features = ["derive"] }
+libfuzzer-sys = "0.4"
 textwrap = { path = ".." }
 
 # Prevent this from interfering with workspaces
 [workspace]
 members = ["."]
+
+[[bin]]
+name = "fill_first_fit"
+path = "fuzz_targets/fill_first_fit.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "wrap_first_fit"
+path = "fuzz_targets/wrap_first_fit.rs"
+test = false
+doc = false
 
 [[bin]]
 name = "fill_optimal_fit"
@@ -24,7 +37,7 @@ test = false
 doc = false
 
 [[bin]]
-name = "fill_first_fit"
-path = "fuzz_targets/fill_first_fit.rs"
+name = "wrap_optimal_fit"
+path = "fuzz_targets/wrap_optimal_fit.rs"
 test = false
 doc = false

--- a/fuzz/fuzz_targets/wrap_first_fit.rs
+++ b/fuzz/fuzz_targets/wrap_first_fit.rs
@@ -1,0 +1,25 @@
+#![no_main]
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+use textwrap::core;
+use textwrap::wrap_algorithms::wrap_first_fit;
+
+#[derive(Arbitrary, Debug, Eq, PartialEq)]
+struct Word {
+    width: usize,
+    whitespace_width: usize,
+    penalty_width: usize,
+}
+
+#[rustfmt::skip]
+impl core::Fragment for Word {
+    fn width(&self) -> usize { self.width }
+    fn whitespace_width(&self) -> usize { self.whitespace_width }
+    fn penalty_width(&self) -> usize { self.penalty_width }
+}
+
+fuzz_target!(|input: (usize, Vec<Word>)| {
+    let width = input.0;
+    let words = input.1;
+    let _ = wrap_first_fit(&words, &[width]);
+});

--- a/fuzz/fuzz_targets/wrap_optimal_fit.rs
+++ b/fuzz/fuzz_targets/wrap_optimal_fit.rs
@@ -1,0 +1,47 @@
+#![no_main]
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+use textwrap::core;
+use textwrap::wrap_algorithms::{wrap_optimal_fit, OptimalFit};
+
+#[derive(Arbitrary, Debug)]
+struct Penalties {
+    nline_penalty: i32,
+    overflow_penalty: i32,
+    short_last_line_fraction: usize,
+    short_last_line_penalty: i32,
+    hyphen_penalty: i32,
+}
+
+impl Into<OptimalFit> for Penalties {
+    fn into(self) -> OptimalFit {
+        OptimalFit {
+            nline_penalty: self.nline_penalty,
+            overflow_penalty: self.overflow_penalty,
+            short_last_line_fraction: std::cmp::max(1, self.short_last_line_fraction),
+            short_last_line_penalty: self.short_last_line_penalty,
+            hyphen_penalty: self.hyphen_penalty,
+        }
+    }
+}
+
+#[derive(Arbitrary, Debug, Eq, PartialEq)]
+struct Word {
+    width: usize,
+    whitespace_width: usize,
+    penalty_width: usize,
+}
+
+#[rustfmt::skip]
+impl core::Fragment for Word {
+    fn width(&self) -> usize { self.width }
+    fn whitespace_width(&self) -> usize { self.whitespace_width }
+    fn penalty_width(&self) -> usize { self.penalty_width }
+}
+
+fuzz_target!(|input: (usize, Vec<Word>, Penalties)| {
+    let width = input.0;
+    let words = input.1;
+    let penalties = input.2.into();
+    let _ = wrap_optimal_fit(&words, &[width], &penalties);
+});


### PR DESCRIPTION
The new `wrap_first_fit.rs` and `wrap_optimal_fit.rs` fuzz tests generate completely random fragments with arbitrary widths. They then check that the fragments can be wrapped without overflow.

The tests currently fail in less than a second and triggers the overflows mentioned in #247 and #416.