### PR TITLE
Change penalties to non-negative numbers

### DIFF
--- a/examples/wasm/src/lib.rs
+++ b/examples/wasm/src/lib.rs
@@ -250,22 +250,22 @@ pub enum WasmWrapAlgorithm {
 #[wasm_bindgen]
 #[derive(Copy, Clone, Debug, Default)]
 pub struct WasmOptimalFit {
-    pub nline_penalty: i32,
-    pub overflow_penalty: i32,
+    pub nline_penalty: usize,
+    pub overflow_penalty: usize,
     pub short_last_line_fraction: usize,
-    pub short_last_line_penalty: i32,
-    pub hyphen_penalty: i32,
+    pub short_last_line_penalty: usize,
+    pub hyphen_penalty: usize,
 }
 
 #[wasm_bindgen]
 impl WasmOptimalFit {
     #[wasm_bindgen(constructor)]
     pub fn new(
-        nline_penalty: i32,
-        overflow_penalty: i32,
+        nline_penalty: usize,
+        overflow_penalty: usize,
         short_last_line_fraction: usize,
-        short_last_line_penalty: i32,
-        hyphen_penalty: i32,
+        short_last_line_penalty: usize,
+        hyphen_penalty: usize,
     ) -> WasmOptimalFit {
         WasmOptimalFit {
             nline_penalty,

--- a/examples/wasm/www/index.html
+++ b/examples/wasm/www/index.html
@@ -97,7 +97,7 @@ You can test the word-wrapping behavior by editing the text 😍✨</textarea>
       <div class="option">
         <label for="overflow-penalty">Overflow penalty:</label>
         <input type="number" id="overflow-penalty-text">
-        <input type="range" id="overflow-penalty" min="-1000" max="10000" value="7500">
+        <input type="range" id="overflow-penalty" min="0" max="10000" value="7500">
       </div>
 
       <div class="option">
@@ -109,13 +109,13 @@ You can test the word-wrapping behavior by editing the text 😍✨</textarea>
       <div class="option">
         <label for="short-last-line-penalty">Short line penalty:</label>
         <input type="number" id="short-last-line-penalty-text">
-        <input type="range" id="short-last-line-penalty" min="-2000" max="2000" value="100">
+        <input type="range" id="short-last-line-penalty" min="0" max="2000" value="100">
       </div>
 
       <div class="option">
         <label for="hyphen-penalty">Hyphen penalty:</label>
         <input type="number" id="hyphen-penalty-text">
-        <input type="range" id="hyphen-penalty" min="-2000" max="2000" value="100">
+        <input type="range" id="hyphen-penalty" min="0" max="2000" value="100">
       </div>
     </div>
 

--- a/fuzz/fuzz_targets/wrap_optimal_fit.rs
+++ b/fuzz/fuzz_targets/wrap_optimal_fit.rs
@@ -6,11 +6,11 @@ use textwrap::wrap_algorithms::{wrap_optimal_fit, OptimalFit};
 
 #[derive(Arbitrary, Debug)]
 struct Penalties {
-    nline_penalty: i32,
-    overflow_penalty: i32,
+    nline_penalty: usize,
+    overflow_penalty: usize,
     short_last_line_fraction: usize,
-    short_last_line_penalty: i32,
-    hyphen_penalty: i32,
+    short_last_line_penalty: usize,
+    hyphen_penalty: usize,
 }
 
 impl Into<OptimalFit> for Penalties {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1392,7 +1392,18 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(feature = "smawk"))]
     fn max_width() {
+        // No overflow for the first-fit wrap algorithm.
+        assert_eq!(wrap("foo bar", usize::max_value()), vec!["foo bar"]);
+    }
+
+    #[test]
+    #[cfg(feature = "smawk")]
+    #[should_panic(expected = "attempt to multiply with overflow")]
+    fn max_width() {
+        // The optimal-fit algorithm overflows for extreme line
+        // widths. See #247 and #416 for details..
         assert_eq!(wrap("foo bar", usize::max_value()), vec!["foo bar"]);
     }
 

--- a/src/wrap_algorithms/optimal_fit.rs
+++ b/src/wrap_algorithms/optimal_fit.rs
@@ -24,7 +24,7 @@ use crate::wrap_algorithms::WrapAlgorithm;
 pub struct OptimalFit {
     /// Per-line penalty. This is added for every line, which makes it
     /// expensive to output more lines than the minimum required.
-    pub nline_penalty: i32,
+    pub nline_penalty: usize,
 
     /// Per-character cost for lines that overflow the target line width.
     ///
@@ -67,7 +67,7 @@ pub struct OptimalFit {
     /// character. If it overflows by more than one character, the
     /// overflow penalty will quickly outgrow the cost of the gap, as
     /// seen above.
-    pub overflow_penalty: i32,
+    pub overflow_penalty: usize,
 
     /// When should the a single word on the last line be considered
     /// "too short"?
@@ -128,10 +128,10 @@ pub struct OptimalFit {
     /// Penalty for a last line with a single short word.
     ///
     /// Set this to zero if you do not want to penalize short last lines.
-    pub short_last_line_penalty: i32,
+    pub short_last_line_penalty: usize,
 
     /// Penalty for lines ending with a hyphen.
-    pub hyphen_penalty: i32,
+    pub hyphen_penalty: usize,
 }
 
 impl OptimalFit {
@@ -308,12 +308,12 @@ pub fn wrap_optimal_fit<'a, 'b, T: Fragment>(
         // Next, we add a penalty depending on the line length.
         if line_width > target_width {
             // Lines that overflow get a hefty penalty.
-            let overflow = (line_width - target_width) as i32;
+            let overflow = line_width - target_width;
             cost += overflow * penalties.overflow_penalty;
         } else if j < fragments.len() {
             // Other lines (except for the last line) get a milder
             // penalty which depend on the size of the gap.
-            let gap = (target_width - line_width) as i32;
+            let gap = target_width - line_width;
             cost += gap * gap;
         } else if i + 1 == j && line_width < target_width / penalties.short_last_line_fraction {
             // The last line can have any size gap, but we do add a


### PR DESCRIPTION
The optimization problem solved by the optimal-fit algorithm is fundamentally an optimization problem where we seek to minimize a penalty cost. It is therefore not sensible to allow negative penalties since all penalties are there to discourage certain features:

* `nline_penalty` discourages breaks with more lines than necessary,

* `overflow_penalty` discourages lines longer than the line width,

* `short_last_line_penalty` discourages short last lines,

* `hyphen_penalty` discourages hyphenation

Making this change surfaces the overflow bug behind #247 and #416. This will be fixed next via #421 and this commit can be seen as a way of simplifying that PR.