### PR TITLE
Use precise dependency versions in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,18 +37,18 @@ path = "benches/indent.rs"
 default = ["unicode-linebreak", "unicode-width", "smawk"]
 
 [dependencies]
-hyphenation = { version = "0.8.2", optional = true, features = ["embed_en-us"] }
-smawk = { version = "0.3", optional = true }
-terminal_size = { version = "0.1", optional = true }
-unicode-linebreak = { version = "0.1", optional = true }
-unicode-width = { version= "0.1", optional = true }
+hyphenation = { version = "0.8.4", optional = true, features = ["embed_en-us"] }
+smawk = { version = "0.3.1", optional = true }
+terminal_size = { version = "0.1.17", optional = true }
+unicode-linebreak = { version = "0.1.2", optional = true }
+unicode-width = { version = "0.1.9", optional = true }
 
 [dev-dependencies]
-criterion = "0.3"
-lipsum = "0.8"
+criterion = "0.3.5"
+lipsum = "0.8.0"
 unic-emoji-char = "0.9.0"
-version-sync = "0.9"
-doc-comment = "0.3"
+version-sync = "0.9.4"
+doc-comment = "0.3.3"
 
 [target.'cfg(unix)'.dev-dependencies]
-termion = "1.5"
+termion = "1.5.6"

--- a/examples/wasm/Cargo.lock
+++ b/examples/wasm/Cargo.lock
@@ -35,9 +35,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.55"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
+checksum = "a38fc24e30fd564ce974c02bf1d337caddff65be6cc4735a1f7eab22a7440f04"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -172,9 +172,9 @@ checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
+checksum = "25f1af7423d8588a3d840681122e72e6a24ddbcb3f0ec385cac0d12d24256c06"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -182,9 +182,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a317bf8f9fba2476b4b2c85ef4c4af8ff39c3c7f0cdfeed4f82c34a880aa837b"
+checksum = "8b21c0df030f5a177f3cba22e9bc4322695ec43e7257d865302900290bcdedca"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -197,9 +197,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8d7523cb1f2a4c96c1317ca690031b714a51cc14e05f712446691f413f5d39"
+checksum = "2eb6ec270a31b1d3c7e266b999739109abce8b6c87e4b31fcfcd788b65267395"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -209,9 +209,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9"
+checksum = "2f4203d69e40a52ee523b2529a773d5ffc1dc0071801c87b3d270b471b80ed01"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -219,9 +219,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
+checksum = "bfa8a30d46208db204854cadbb5d4baf5fcf8071ba5bf48190c3e59937962ebc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -232,15 +232,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
+checksum = "3d958d035c4438e28c70e4321a2911302f10135ce78a9c7834c0cab4123d06a2"
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96f1aa7971fdf61ef0f353602102dbea75a56e225ed036c1e3740564b91e6b7e"
+checksum = "45c8d417d87eefa0087e62e3c75ad086be39433449e2961add9a5d9ce5acc2f1"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",
@@ -252,9 +252,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6006f79628dfeb96a86d4db51fbf1344cd7fd8408f06fc9aa3c84913a4789688"
+checksum = "d0e560d44db5e73b69a9757a15512fe7e1ef93ed2061c928871a4025798293dd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -262,9 +262,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.55"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38eb105f1c59d9eaa6b5cdc92b859d85b926e82cb2e0945cd0c9259faa6fe9fb"
+checksum = "c060b319f29dd25724f09a2ba1418f142f539b2be99fbf4d2d5a8f7330afb8eb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/examples/wasm/Cargo.toml
+++ b/examples/wasm/Cargo.toml
@@ -14,14 +14,14 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 textwrap = { path = "../../" }
 
-console_error_panic_hook = "0.1"
-js-sys = "0.3"
-wasm-bindgen = "0.2"
-web-sys = { version = "0.3", features = ["CanvasRenderingContext2d", "TextMetrics"] }
-unicode-segmentation = "1.7"
+console_error_panic_hook = "0.1.7"
+js-sys = "0.3.56"
+wasm-bindgen = "0.2.79"
+web-sys = { version = "0.3.56", features = ["CanvasRenderingContext2d", "TextMetrics"] }
+unicode-segmentation = "1.8.0"
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3"
+wasm-bindgen-test = "0.3.29"
 
 [profile.release]
 opt-level = "s"  # Optimize for small code size

--- a/examples/wasm/www/package-lock.json
+++ b/examples/wasm/www/package-lock.json
@@ -20,6 +20,7 @@
             }
         },
         "../pkg": {
+            "name": "textwrap-wasm-demo",
             "version": "0.1.0",
             "license": "SEE LICENSE IN ../../LICENSE"
         },

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2018"
 cargo-fuzz = true
 
 [dependencies]
-arbitrary = { version = "1", features = ["derive"] }
-libfuzzer-sys = "0.4"
+arbitrary = { version = "1.0.3", features = ["derive"] }
+libfuzzer-sys = "0.4.2"
 textwrap = { path = ".." }
 
 # Prevent this from interfering with workspaces


### PR DESCRIPTION
Following [the advice from the Rust forum][1], this PR updates Cargo.toml to use precise version numbers for all dependencies. The latest versions at the time of writing are used.

It turns out that we made precisely the mistake mentioned in the post:

```
% cargo -Z minimal-versions update
% cargo test
```

failed on nightly because of the dependency on smawk 0.3: we need 0.3.1 after #421.

[1]: https://users.rust-lang.org/t/psa-please-specify-precise-dependency-versions-in-cargo-toml/71277