### PR TITLE
Fix renamed `broken_intra_doc_links` lint

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Build documentation and check intra-doc links
         env:
-          RUSTDOCFLAGS: --deny broken_intra_doc_links
+          RUSTDOCFLAGS: --deny rustdoc::broken_intra_doc_links
         run: cargo doc --all-features --no-deps
 
   clippy:


### PR DESCRIPTION
The lint has been renamed to `rustdoc::broken_intra_doc_links`.