### PR TITLE
Merge imports from the same module into a single `use` statement

### DIFF
--- a/benches/indent.rs
+++ b/benches/indent.rs
@@ -1,5 +1,4 @@
-use criterion::Criterion;
-use criterion::{criterion_group, criterion_main};
+use criterion::{criterion_group, criterion_main, Criterion};
 
 pub fn benchmark(c: &mut Criterion) {
     // Generate a piece of text with some empty lines.

--- a/benches/linear.rs
+++ b/benches/linear.rs
@@ -1,8 +1,6 @@
 use std::time::Duration;
 
-use criterion::BenchmarkId;
-use criterion::Criterion;
-use criterion::{criterion_group, criterion_main};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 
 // The benchmarks here verify that the complexity grows as O(*n*)
 // where *n* is the number of characters in the text to be wrapped.

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+imports_granularity = "Module"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,8 +203,7 @@ mod readme_doctest {}
 use std::borrow::Cow;
 
 mod indentation;
-pub use crate::indentation::dedent;
-pub use crate::indentation::indent;
+pub use crate::indentation::{dedent, indent};
 
 mod word_separators;
 pub use word_separators::WordSeparator;
@@ -358,7 +357,7 @@ impl<'a> Options<'a> {
     /// initial indentation and wrapping each paragraph by itself:
     ///
     /// ```
-    /// use textwrap::{Options, wrap};
+    /// use textwrap::{wrap, Options};
     ///
     /// let options = Options::new(16).initial_indent("    ");
     /// assert_eq!(wrap("This is a little example.", options),
@@ -383,7 +382,7 @@ impl<'a> Options<'a> {
     /// single paragraph as a bullet list:
     ///
     /// ```
-    /// use textwrap::{Options, wrap};
+    /// use textwrap::{wrap, Options};
     ///
     /// let options = Options::new(12)
     ///     .initial_indent("* ")

--- a/src/word_separators.rs
+++ b/src/word_separators.rs
@@ -73,8 +73,8 @@ pub enum WordSeparator {
     ///
     /// ```
     /// #[cfg(feature = "unicode-linebreak")] {
-    /// use textwrap::WordSeparator::UnicodeBreakProperties;
     /// use textwrap::core::Word;
+    /// use textwrap::WordSeparator::UnicodeBreakProperties;
     ///
     /// assert_eq!(UnicodeBreakProperties.find_words("Emojis: 😂😍").collect::<Vec<_>>(),
     ///            vec![Word::from("Emojis: "),
@@ -93,8 +93,8 @@ pub enum WordSeparator {
     ///
     /// ```
     /// #[cfg(feature = "unicode-linebreak")] {
-    /// use textwrap::WordSeparator::UnicodeBreakProperties;
     /// use textwrap::core::Word;
+    /// use textwrap::WordSeparator::UnicodeBreakProperties;
     ///
     /// assert_eq!(UnicodeBreakProperties.find_words("Emojis: 😂\u{2060}😍").collect::<Vec<_>>(),
     ///            vec![Word::from("Emojis: "),
@@ -107,8 +107,8 @@ pub enum WordSeparator {
     ///
     /// ```
     /// #[cfg(feature = "unicode-linebreak")] {
-    /// use textwrap::WordSeparator::UnicodeBreakProperties;
     /// use textwrap::core::Word;
+    /// use textwrap::WordSeparator::UnicodeBreakProperties;
     ///
     /// assert_eq!(UnicodeBreakProperties.find_words("[ foo ] bar !").collect::<Vec<_>>(),
     ///            vec![Word::from("[ foo ] "),

--- a/src/wrap_algorithms.rs
+++ b/src/wrap_algorithms.rs
@@ -239,8 +239,8 @@ impl Default for WrapAlgorithm {
 /// on your estimates. You can model this with a program like this:
 ///
 /// ```
-/// use textwrap::wrap_algorithms::wrap_first_fit;
 /// use textwrap::core::{Fragment, Word};
+/// use textwrap::wrap_algorithms::wrap_first_fit;
 ///
 /// #[derive(Debug)]
 /// struct Task<'a> {

--- a/src/wrap_algorithms/optimal_fit.rs
+++ b/src/wrap_algorithms/optimal_fit.rs
@@ -34,8 +34,8 @@ pub struct Penalties {
     /// character in extreme cases:
     ///
     /// ```
-    /// use textwrap::wrap_algorithms::{wrap_optimal_fit, Penalties};
     /// use textwrap::core::Word;
+    /// use textwrap::wrap_algorithms::{wrap_optimal_fit, Penalties};
     ///
     /// let short = "foo ";
     /// let long = "x".repeat(50);
@@ -276,7 +276,7 @@ impl std::error::Error for OverflowError {}
 ///
 /// ```
 /// use textwrap::core::Fragment;
-/// use textwrap::wrap_algorithms::{wrap_optimal_fit, Penalties, OverflowError};
+/// use textwrap::wrap_algorithms::{wrap_optimal_fit, OverflowError, Penalties};
 ///
 /// #[derive(Debug, PartialEq)]
 /// struct Word(f64);


### PR DESCRIPTION
This standardizes the formatting for `use` statements: they're now sorted and imports are merged by module.
