### PR TITLE
Update binary sizes for Rust 1.59

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,16 +146,16 @@
 //!   This feature can be disabled if you only ever intend to use
 //!   [`wrap_algorithms::wrap_first_fit`].
 //!
-//! With Rust 1.54.0, the size impact of the above features on your
+//! With Rust 1.59.0, the size impact of the above features on your
 //! binary is as follows:
 //!
 //! | Configuration                            |  Binary Size |    Delta |
 //! | :---                                     |         ---: |     ---: |
-//! | quick-and-dirty implementation           |       252 KB |     — KB |
-//! | textwrap without default features        |       268 KB |    16 KB |
-//! | textwrap with smawk                      |       284 KB |    32 KB |
-//! | textwrap with unicode-width              |       276 KB |    24 KB |
-//! | textwrap with unicode-linebreak          |       362 KB |   110 KB |
+//! | quick-and-dirty implementation           |       289 KB |     — KB |
+//! | textwrap without default features        |       301 KB |    12 KB |
+//! | textwrap with smawk                      |       317 KB |    28 KB |
+//! | textwrap with unicode-width              |       313 KB |    24 KB |
+//! | textwrap with unicode-linebreak          |       395 KB |   106 KB |
 //!
 //! The above sizes are the stripped sizes and the binary is compiled
 //! in release mode with this profile:


### PR DESCRIPTION
Compared to 1.54 in #415, the binaries have grown by about 30 KB across the board (also for the quick-and-dirty implementation).

This step should of course be automated as part of the release process, but for now I do it by hand.