### PR TITLE
Revert "Put single-expression functions on a single line"

### DIFF
--- a/fuzz/fuzz_targets/wrap_first_fit.rs
+++ b/fuzz/fuzz_targets/wrap_first_fit.rs
@@ -11,6 +11,7 @@ struct Word {
     penalty_width: f64,
 }
 
+#[rustfmt::skip]
 impl core::Fragment for Word {
     fn width(&self) -> f64 { self.width }
     fn whitespace_width(&self) -> f64 { self.whitespace_width }

--- a/fuzz/fuzz_targets/wrap_optimal_fit.rs
+++ b/fuzz/fuzz_targets/wrap_optimal_fit.rs
@@ -32,6 +32,7 @@ struct Word {
     penalty_width: f64,
 }
 
+#[rustfmt::skip]
 impl core::Fragment for Word {
     fn width(&self) -> f64 { self.width }
     fn whitespace_width(&self) -> f64 { self.whitespace_width }

--- a/fuzz/fuzz_targets/wrap_optimal_fit_usize.rs
+++ b/fuzz/fuzz_targets/wrap_optimal_fit_usize.rs
@@ -32,6 +32,7 @@ struct Word {
     penalty_width: usize,
 }
 
+#[rustfmt::skip]
 impl core::Fragment for Word {
     fn width(&self) -> f64 { self.width as f64 }
     fn whitespace_width(&self) -> f64 { self.whitespace_width as f64 }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,1 @@
-fn_single_line = true
 imports_granularity = "Module"

--- a/src/core.rs
+++ b/src/core.rs
@@ -61,7 +61,9 @@ pub(crate) fn skip_ansi_escape_sequence<I: Iterator<Item = char>>(ch: char, char
 
 #[cfg(feature = "unicode-width")]
 #[inline]
-fn ch_width(ch: char) -> usize { unicode_width::UnicodeWidthChar::width(ch).unwrap_or(0) }
+fn ch_width(ch: char) -> usize {
+    unicode_width::UnicodeWidthChar::width(ch).unwrap_or(0)
+}
 
 /// First character which [`ch_width`] will classify as double-width.
 /// Please see [`display_width`].
@@ -224,7 +226,9 @@ pub struct Word<'a> {
 impl std::ops::Deref for Word<'_> {
     type Target = str;
 
-    fn deref(&self) -> &Self::Target { self.word }
+    fn deref(&self) -> &Self::Target {
+        self.word
+    }
 }
 
 impl<'a> Word<'a> {
@@ -299,17 +303,23 @@ impl<'a> Word<'a> {
 
 impl Fragment for Word<'_> {
     #[inline]
-    fn width(&self) -> f64 { self.width as f64 }
+    fn width(&self) -> f64 {
+        self.width as f64
+    }
 
     // We assume the whitespace consist of ' ' only. This allows us to
     // compute the display width in constant time.
     #[inline]
-    fn whitespace_width(&self) -> f64 { self.whitespace.len() as f64 }
+    fn whitespace_width(&self) -> f64 {
+        self.whitespace.len() as f64
+    }
 
     // We assume the penalty is `""` or `"-"`. This allows us to
     // compute the display width in constant time.
     #[inline]
-    fn penalty_width(&self) -> f64 { self.penalty.len() as f64 }
+    fn penalty_width(&self) -> f64 {
+        self.penalty.len() as f64
+    }
 }
 
 /// Forcibly break words wider than `line_width` into smaller words.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -273,7 +273,9 @@ impl<'a> From<&'a Options<'a>> for Options<'a> {
 }
 
 impl<'a> From<usize> for Options<'a> {
-    fn from(width: usize) -> Self { Options::new(width) }
+    fn from(width: usize) -> Self {
+        Options::new(width)
+    }
 }
 
 impl<'a> Options<'a> {
@@ -340,7 +342,9 @@ impl<'a> Options<'a> {
     /// **Note:** Only available when the `terminal_size` feature is
     /// enabled.
     #[cfg(feature = "terminal_size")]
-    pub fn with_termwidth() -> Self { Self::new(termwidth()) }
+    pub fn with_termwidth() -> Self {
+        Self::new(termwidth())
+    }
 }
 
 impl<'a> Options<'a> {
@@ -1837,5 +1841,7 @@ mod tests {
 
     #[test]
     #[should_panic]
-    fn wrap_columns_panic_with_zero_columns() { wrap_columns("", 0, 10, "", "", ""); }
+    fn wrap_columns_panic_with_zero_columns() {
+        wrap_columns("", 0, 10, "", "", "");
+    }
 }

--- a/src/wrap_algorithms.rs
+++ b/src/wrap_algorithms.rs
@@ -122,7 +122,9 @@ impl WrapAlgorithm {
     /// **Note:** Only available when the `smawk` Cargo feature is
     /// enabled.
     #[cfg(feature = "smawk")]
-    pub const fn new_optimal_fit() -> Self { WrapAlgorithm::OptimalFit(Penalties::new()) }
+    pub const fn new_optimal_fit() -> Self {
+        WrapAlgorithm::OptimalFit(Penalties::new())
+    }
 
     /// Wrap words according to line widths.
     ///
@@ -157,7 +159,9 @@ impl WrapAlgorithm {
 }
 
 impl Default for WrapAlgorithm {
-    fn default() -> Self { WrapAlgorithm::new() }
+    fn default() -> Self {
+        WrapAlgorithm::new()
+    }
 }
 
 /// Wrap abstract fragments into lines with a first-fit algorithm.
@@ -341,6 +345,7 @@ mod tests {
     #[derive(Debug, PartialEq)]
     struct Word(f64);
 
+    #[rustfmt::skip]
     impl Fragment for Word {
         fn width(&self) -> f64 { self.0 }
         fn whitespace_width(&self) -> f64 { 1.0 }

--- a/src/wrap_algorithms/optimal_fit.rs
+++ b/src/wrap_algorithms/optimal_fit.rs
@@ -150,7 +150,9 @@ impl Penalties {
 }
 
 impl Default for Penalties {
-    fn default() -> Self { Self::new() }
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 /// Cache for line numbers. This is necessary to avoid a O(n**2)
@@ -393,6 +395,7 @@ mod tests {
     #[derive(Debug, PartialEq)]
     struct Word(f64);
 
+    #[rustfmt::skip]
     impl Fragment for Word {
         fn width(&self) -> f64 { self.0 }
         fn whitespace_width(&self) -> f64 { 1.0 }


### PR DESCRIPTION
This reverts commit 4ce32d6d878fe9c500e331b3553c9f6d7ae2d145.

Changing the default formatting using an unstable `rustfmt` feature
was a bad idea: it means that people who have auto-formatting turned
on (like me) will see the formatting flip-flop when switching between
stable and nightly.

The problem is that the unstable `fn_single_line` option only takes
effect on nightly, so when `rustfmt` runs on stable, it will add lots
of spurious changes.

The `imports_granularity` option does not have this problem: `rustfmt`
will not modify imports by default and so nothing happens when it is
run on stable.