### PR TITLE
Fix `cargo publish` error due to examples without path

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,12 @@ exclude = [".github/", ".gitignore", "benches/", "examples/", "fuzz/", "images/"
 
 [[example]]
 name = "hyphenation"
+path = "examples/hyphenation.rs"
 required-features = ["hyphenation"]
 
 [[example]]
 name = "termwidth"
+path = "examples/termwidth.rs"
 required-features = ["terminal_size"]
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
Without this, we get a strange error:

```
% cargo publish --dry-run
    Updating crates.io index
   Packaging textwrap v0.15.0 (/home/mg/src/textwrap)
   Verifying textwrap v0.15.0 (/home/mg/src/textwrap)
error: failed to verify package tarball

Caused by:
  failed to parse manifest at `/home/mg/src/textwrap/target/package/textwrap-0.15.0/Cargo.toml`

Caused by:
  can't find `hyphenation` example at `examples/hyphenation.rs` or
  `examples/hyphenation/main.rs`. Please specify example.path if you
  want to use a non-default path.
```

This happens even though the file is there:

```
% ls examples/hyphenation.rs
examples/hyphenation.rs
```

Specifying an explicit path helps and should let the release go
through.