### PR TITLE
Migrate to the Rust 2021 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 keywords = ["text", "formatting", "wrap", "typesetting", "hyphenation"]
 categories = ["text-processing", "command-line-interface"]
 license = "MIT"
-edition = "2018"
+edition = "2021"
 exclude = [".github/", ".gitignore", "benches/", "examples/", "fuzz/", "images/"]
 
 [[example]]

--- a/examples/binary-sizes/Cargo.toml
+++ b/examples/binary-sizes/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Martin Geisler <martin@geisler.net>"]
 description = "Textwrap binary size demo"
 repository = "https://github.com/mgeisler/textwrap"
 license-file = "../../LICENSE"
-edition = "2018"
+edition = "2021"
 publish = false  # This demo project should not be uploaded to crates.io
 
 [profile.release]

--- a/examples/wasm/Cargo.toml
+++ b/examples/wasm/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Martin Geisler <martin@geisler.net>"]
 description = "Textwrap WebAssembly demo"
 repository = "https://github.com/mgeisler/textwrap"
 license-file = "../../LICENSE"
-edition = "2018"
+edition = "2021"
 publish = false  # This project should not be uploaded to crates.io
 
 [lib]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -4,7 +4,7 @@ name = "textwrap-fuzz"
 version = "0.0.0"
 authors = ["Automatically generated"]
 publish = false
-edition = "2018"
+edition = "2021"
 
 [package.metadata]
 cargo-fuzz = true


### PR DESCRIPTION
No changes necessary.