### PR TITLE
Add explicit `LICENSE` file to Wasm demo

### DIFF
--- a/examples/wasm/Cargo.toml
+++ b/examples/wasm/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Martin Geisler <martin@geisler.net>"]
 description = "Textwrap WebAssembly demo"
 repository = "https://github.com/mgeisler/textwrap"
-license-file = "../../LICENSE"
+license = "MIT"
 edition = "2021"
 publish = false  # This project should not be uploaded to crates.io
 

--- a/examples/wasm/LICENSE
+++ b/examples/wasm/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Martin Geisler
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/examples/wasm/www/package-lock.json
+++ b/examples/wasm/www/package-lock.json
@@ -21,7 +21,7 @@
         "../pkg": {
             "name": "textwrap-wasm-demo",
             "version": "0.1.0",
-            "license": "SEE LICENSE IN ../../LICENSE"
+            "license": "MIT"
         },
         "node_modules/@discoveryjs/json-ext": {
             "version": "0.5.7",


### PR DESCRIPTION
Using the `license-file` field makes `wasm-pack build` generate an untracked `examples/LICENSE` file every time we build the project.