### PR TITLE
Add configurable LineEnding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,11 @@ name = "indent"
 harness = false
 path = "benches/indent.rs"
 
+[[bench]]
+name = "unfill"
+harness = false
+path = "benches/unfill.rs"
+
 [features]
 default = ["unicode-linebreak", "unicode-width", "smawk"]
 

--- a/benches/unfill.rs
+++ b/benches/unfill.rs
@@ -1,0 +1,23 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+
+pub fn benchmark(c: &mut Criterion) {
+    let words_per_line = [
+        5, 10, 15, 5, 5, 10, 5, 5, 5, 10, // 10 lines
+        10, 10, 5, 5, 5, 5, 15, 10, 5, 5, // 20 lines
+        10, 5, 5, 5, 15, 10, 10, 5, 5, 5, // 30 lines
+        15, 5, 5, 10, 5, 5, 5, 15, 5, 10, // 40 lines
+        5, 15, 5, 5, 15, 5, 10, 10, 5, 5, // 50 lines
+    ];
+    let mut text = String::new();
+    for (line_no, word_count) in words_per_line.iter().enumerate() {
+        text.push_str(&lipsum::lipsum_words_from_seed(*word_count, line_no as u64));
+        text.push('\n');
+    }
+    text.push_str("\n\n\n\n");
+    assert_eq!(text.len(), 2650); // The size for reference.
+
+    c.bench_function("unfill", |b| b.iter(|| textwrap::unfill(&text)));
+}
+
+criterion_group!(benches, benchmark);
+criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,7 +224,7 @@ pub mod core;
 pub struct Options<'a> {
     /// The width in columns at which the text will be wrapped.
     pub width: usize,
-    /// TODO doc
+    /// Line ending used for breaking lines.
     pub line_ending: LineEnding,
     /// Indentation used for the first line of output. See the
     /// [`Options::initial_indent`] method.
@@ -341,7 +341,21 @@ impl<'a> Options<'a> {
         Self::new(termwidth())
     }
 
-    /// TODO
+    /// Change [`self.line_ending`]. This specifies which of the
+    /// supported line endings should be used to break the lines of the
+    /// input text.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use textwrap::{refill, LineEnding, Options};
+    ///
+    /// let options = Options::new(15).line_ending(LineEnding::CRLF);
+    /// assert_eq!(refill("This is a little example.", options),
+    ///            "This is a\r\nlittle example.");
+    /// ```
+    ///
+    /// [`self.line_ending`]: #structfield.line_ending
     pub fn line_ending(self, line_ending: LineEnding) -> Self {
         Options {
             line_ending,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -601,10 +601,16 @@ where
 /// textwrap: a small library for wrapping text.
 /// ```
 ///
-/// In addition, it will recognize a common prefix among the lines.
+/// In addition, it will recognize a common prefix and a common line
+/// ending among the lines.
+///
 /// The prefix of the first line is returned in
 /// [`Options::initial_indent`] and the prefix (if any) of the the
 /// other lines is returned in [`Options::subsequent_indent`].
+///
+/// Line ending is returned in [`Options::line_ending`]. If line ending
+/// can not be confidently detected (mixed or no line endings in the
+/// input), [`LineEnding::LF`] will be returned.
 ///
 /// In addition to `' '`, the prefixes can consist of characters used
 /// for unordered lists (`'-'`, `'+'`, and `'*'`) and block quotes

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -648,6 +648,7 @@ where
 /// assert_eq!(text, "This is an example of a list item.\n");
 /// assert_eq!(options.initial_indent, "* ");
 /// assert_eq!(options.subsequent_indent, "  ");
+/// assert_eq!(options.line_ending, LineEnding::LF);
 /// ```
 pub fn unfill(text: &str) -> (String, Options<'_>) {
     let line_ending_pat: &[_] = &['\r', '\n'];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,7 +214,7 @@ pub use word_splitters::WordSplitter;
 pub mod wrap_algorithms;
 pub use wrap_algorithms::WrapAlgorithm;
 
-pub mod line_ending;
+mod line_ending;
 pub use line_ending::LineEnding;
 
 pub mod core;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -650,7 +650,8 @@ where
 /// assert_eq!(options.subsequent_indent, "  ");
 /// ```
 pub fn unfill(text: &str) -> (String, Options<'_>) {
-    let trimmed = text.trim_end_matches(&['\r', '\n']);
+    let line_ending_pat: &[_] = &['\r', '\n'];
+    let trimmed = text.trim_end_matches(line_ending_pat);
     let prefix_chars: &[_] = &[' ', '-', '+', '*', '>', '#', '/'];
 
     let mut options = Options::new(0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -656,7 +656,7 @@ pub fn unfill(text: &str) -> (String, Options<'_>) {
     let prefix_chars: &[_] = &[' ', '-', '+', '*', '>', '#', '/'];
 
     let mut options = Options::new(0);
-    for (idx, line) in trimmed.split('\n').enumerate() {
+    for (idx, line) in trimmed.lines().enumerate() {
         options.width = std::cmp::max(options.width, core::display_width(line));
         let without_prefix = line.trim_start_matches(prefix_chars);
         let prefix = &line[..line.len() - without_prefix.len()];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -922,7 +922,7 @@ where
 {
     let options: Options = width_or_options.into();
 
-    let line_ending_pat = options.line_ending.as_str();
+    let line_ending_str = options.line_ending.as_str();
 
     let initial_width = options
         .width
@@ -932,7 +932,7 @@ where
         .saturating_sub(core::display_width(options.subsequent_indent));
 
     let mut lines = Vec::new();
-    for line in text.split(line_ending_pat) {
+    for line in text.split(line_ending_str) {
         let words = options.word_separator.find_words(line);
         let split_words = word_splitters::split_words(words, &options.word_splitter);
         let broken_words = if options.break_words {
@@ -1831,6 +1831,14 @@ mod tests {
     #[test]
     fn unfill_whitespace() {
         assert_eq!(unfill("foo   bar").0, "foo   bar");
+    }
+
+    #[test]
+    fn refill_convert_crlf() {
+        assert_eq!(
+            refill("foo\nbar\n", Options::new(5).line_ending(LineEnding::CRLF)),
+            "foo\r\nbar\n",
+        );
     }
 
     #[test]

--- a/src/line_ending.rs
+++ b/src/line_ending.rs
@@ -38,7 +38,7 @@ impl FromStr for LineEnding {
 
 /// TODO
 #[derive(Debug, Clone, Copy)]
-pub struct NonEmptyLines<'a>(pub &'a str);
+pub(crate) struct NonEmptyLines<'a>(pub &'a str);
 
 impl<'a> Iterator for NonEmptyLines<'a> {
     type Item = (&'a str, Option<LineEnding>);

--- a/src/line_ending.rs
+++ b/src/line_ending.rs
@@ -1,0 +1,50 @@
+//! TODO
+
+use std::str::FromStr;
+
+/// TODO doc
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum LineEnding {
+    /// TODO
+    CR,
+    /// TODO
+    CRLF,
+    /// TODO
+    LF,
+}
+
+impl LineEnding {
+    /// TODO
+    #[inline]
+    pub const fn len_chars(&self) -> usize {
+        match self {
+            Self::CRLF => 2,
+            _ => 1,
+        }
+    }
+
+    /// TODO
+    #[inline]
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::CRLF => "\u{000D}\u{000A}",
+            Self::LF => "\u{000A}",
+            Self::CR => "\u{000D}",
+        }
+    }
+}
+
+impl FromStr for LineEnding {
+    // TODO add a descriptive error
+    type Err = ();
+
+    #[inline]
+    fn from_str(s: &str) -> Result<LineEnding, ()> {
+        match s {
+            "\u{000D}\u{000A}" => Result::Ok(LineEnding::CRLF),
+            "\u{000A}" => Result::Ok(LineEnding::LF),
+            "\u{000D}" => Result::Ok(LineEnding::CR),
+            _ => Result::Err(()),
+        }
+    }
+}

--- a/src/line_ending.rs
+++ b/src/line_ending.rs
@@ -1,6 +1,6 @@
 //! Line ending detection and conversion.
 
-use std::fmt::{Debug, Formatter};
+use std::fmt::Debug;
 
 /// Supported line endings. Like in the Rust standard library, two line
 /// endings are supported: `\r\n` and `\n`
@@ -14,19 +14,6 @@ pub enum LineEnding {
     ///  Corresponds to the ASCII control character `0x0A` or `\n`
     LF,
 }
-
-/// Returned when attempted creating [`LineEnding`] value from an
-/// unsupported `&str` value
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct UnsupportedLineEnding;
-
-impl std::fmt::Display for UnsupportedLineEnding {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "unsupported line ending sequence")
-    }
-}
-
-impl std::error::Error for UnsupportedLineEnding {}
 
 impl LineEnding {
     /// Turns this [`LineEnding`] value into its ASCII representation.

--- a/src/line_ending.rs
+++ b/src/line_ending.rs
@@ -1,17 +1,16 @@
 //! Line ending detection and conversion.
 
 use std::fmt::{Debug, Formatter};
-use std::str::FromStr;
 
-/// Supported line endings. Like in the Rust's standard library, two
-/// line endings are supported: `\r\n` and `\n`
+/// Supported line endings. Like in the Rust standard library, two line
+/// endings are supported: `\r\n` and `\n`
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum LineEnding {
     /// _Carriage return and line feed_ – a line ending sequence
-    /// historically used in _Windows_. Corresponds to the sequence
+    /// historically used in Windows. Corresponds to the sequence
     /// of ASCII control characters `0x0D 0x0A` or `\r\n`
     CRLF,
-    /// _Line feed_ – a line ending historically used in _Unix_.
+    /// _Line feed_ – a line ending historically used in Unix.
     ///  Corresponds to the ASCII control character `0x0A` or `\n`
     LF,
 }
@@ -36,19 +35,6 @@ impl LineEnding {
         match self {
             Self::CRLF => "\r\n",
             Self::LF => "\n",
-        }
-    }
-}
-
-impl FromStr for LineEnding {
-    type Err = UnsupportedLineEnding;
-
-    #[inline]
-    fn from_str(s: &str) -> Result<LineEnding, UnsupportedLineEnding> {
-        match s {
-            "\u{000D}\u{000A}" => Ok(LineEnding::CRLF),
-            "\u{000A}" => Ok(LineEnding::LF),
-            _ => Err(UnsupportedLineEnding),
         }
     }
 }
@@ -89,8 +75,7 @@ impl<'a> Iterator for NonEmptyLines<'a> {
 
 #[cfg(test)]
 mod tests {
-    use crate::line_ending::NonEmptyLines;
-    use crate::LineEnding;
+    use super::*;
 
     #[test]
     fn non_empty_lines_full_case() {


### PR DESCRIPTION
This is a quick demonstration of how configurable line ending support would look like #453 .

Immediately I see an issue with `unfill` which now requires `LineEnding` parameter, degrading experience for the clients who do not wish to deal with configurable line endings.

Perhaps, we could have two fns: `unfill_with_endings(&str, LineEnding)` and `unfill(&str) { unfill_with_endings(str, LineEnding::LF) }`

Alternatives to consider
- using `lines()` in `unfill` (trimming trailing `\r\n` could be implemented as discarding trailing empty lines)
- autodetecting the end of the line by examining the input and matching against a set of known patterns
 
My gut feeling is that explicit control over the behavior is better (unicode defines multiple other options over the well-known `CR` and `LF`), but I do not think this is a strong argument considering `lines()` only recognizes `\n` and `\r\n`.

If the overall approach (or any of the alternatives) seems reasonable, I'll work towards finalizing this by providing tests, documentation, etc.. Let me know please.