### PR TITLE
Remove old macro, move logic to `WordSeparator::new`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,20 +216,6 @@ pub use wrap_algorithms::WrapAlgorithm;
 
 pub mod core;
 
-#[cfg(feature = "unicode-linebreak")]
-macro_rules! DefaultWordSeparator {
-    () => {
-        WordSeparator::UnicodeBreakProperties
-    };
-}
-
-#[cfg(not(feature = "unicode-linebreak"))]
-macro_rules! DefaultWordSeparator {
-    () => {
-        WordSeparator::AsciiSpace
-    };
-}
-
 /// Holds configuration options for wrapping and filling text.
 #[derive(Debug, Clone)]
 pub struct Options<'a> {
@@ -318,7 +304,7 @@ impl<'a> Options<'a> {
             initial_indent: "",
             subsequent_indent: "",
             break_words: true,
-            word_separator: DefaultWordSeparator!(),
+            word_separator: WordSeparator::new(),
             wrap_algorithm: WrapAlgorithm::new(),
             word_splitter: WordSplitter::HyphenSplitter,
         }

--- a/src/word_separators.rs
+++ b/src/word_separators.rs
@@ -134,6 +134,23 @@ impl std::fmt::Debug for WordSeparator {
 }
 
 impl WordSeparator {
+    /// Create a new word separator.
+    ///
+    /// The best available algorithm is used by default, i.e.,
+    /// [`WordSeparator::UnicodeBreakProperties`] if available,
+    /// otherwise [`WordSeparator::AsciiSpace`].
+    pub const fn new() -> Self {
+        #[cfg(feature = "unicode-linebreak")]
+        {
+            WordSeparator::UnicodeBreakProperties
+        }
+
+        #[cfg(not(feature = "unicode-linebreak"))]
+        {
+            WordSeparator::AsciiSpace
+        }
+    }
+
     // This function should really return impl Iterator<Item = Word>, but
     // this isn't possible until Rust supports higher-kinded types:
     // https://github.com/rust-lang/rfcs/blob/master/text/1522-conservative-impl-trait.md
@@ -424,5 +441,14 @@ mod tests {
             UnicodeBreakProperties.find_words(&text),
             vec![Word::from(text)]
         );
+    }
+
+    #[test]
+    fn word_separator_new() {
+        #[cfg(feature = "unicode-linebreak")]
+        assert!(matches!(WordSeparator::new(), UnicodeBreakProperties));
+
+        #[cfg(not(feature = "unicode-linebreak"))]
+        assert!(matches!(WordSeparator::new(), AsciiSpace));
     }
 }


### PR DESCRIPTION
The macro was used back when we mentioned the word separator type in more places. This got simplified with the 0.15.0 release, so we can now remove the macro.