### PR TITLE
Test with Rust 1.56 in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
+          - 1.56  # MSRV, Rust 2021
           - stable
           - nightly
         features:


### PR DESCRIPTION
This our current minimum supported Rust version (MSRV). I gave up on maintaining compatibility with Rust 2018 two years ago in #180, but I hope the update speed of our dependencies has slowed down enough that we can keep compatibility with Rust 1.56 for a while.

If this turns out to be problematic again, then I will bump the MSRV as needed. This will of course be clearly communicated in the release notes for each release.