### PR TITLE
Update to terminal_size 0.2.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ default = ["unicode-linebreak", "unicode-width", "smawk"]
 [dependencies]
 hyphenation = { version = "0.8.4", optional = true, features = ["embed_en-us"] }
 smawk = { version = "0.3.1", optional = true }
-terminal_size = { version = "0.1.17", optional = true }
+terminal_size = { version = "0.2.1", optional = true }
 unicode-linebreak = { version = "0.1.2", optional = true }
 unicode-width = { version = "0.1.9", optional = true }
 


### PR DESCRIPTION
This updates the terminal_size optional dependency to the latest
version, 0.2.

I've tested that the termwidth example works.