### PR TITLE
Fix `unfill` and `refill` crashes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,6 +120,8 @@ jobs:
           - wrap_first_fit
           - wrap_optimal_fit
           - wrap_optimal_fit_usize
+          - unfill
+          - refill
 
     steps:
       - name: Checkout repository

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -47,3 +47,15 @@ name = "wrap_optimal_fit_usize"
 path = "fuzz_targets/wrap_optimal_fit_usize.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "refill"
+path = "fuzz_targets/refill.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "unfill"
+path = "fuzz_targets/unfill.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/refill.rs
+++ b/fuzz/fuzz_targets/refill.rs
@@ -1,0 +1,6 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|input: (String, usize)| {
+    let _ = textwrap::refill(&input.0, input.1);
+});

--- a/fuzz/fuzz_targets/unfill.rs
+++ b/fuzz/fuzz_targets/unfill.rs
@@ -1,0 +1,6 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|input: String| {
+    let _ = textwrap::unfill(&input);
+});

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -681,8 +681,8 @@ pub fn unfill(text: &str) -> (String, Options<'_>) {
     let mut unfilled = String::with_capacity(text.len());
     let mut detected_line_ending = None;
 
-    for (line, ending) in line_ending::NonEmptyLines(text) {
-        if unfilled.is_empty() {
+    for (idx, (line, ending)) in line_ending::NonEmptyLines(text).enumerate() {
+        if idx == 0 {
             unfilled.push_str(&line[options.initial_indent.len()..]);
         } else {
             unfilled.push(' ');
@@ -1848,6 +1848,17 @@ mod tests {
         assert_eq!(options.width, 5);
         assert_eq!(options.initial_indent, "> ");
         assert_eq!(options.subsequent_indent, "> ");
+    }
+
+    #[test]
+    fn unfill_only_prefixes_issue_466() {
+        // Test that we don't crash if the first line has only prefix
+        // chars *and* the second line is shorter than the first line.
+        let (text, options) = unfill("######\nfoo");
+        assert_eq!(text, " foo");
+        assert_eq!(options.width, 6);
+        assert_eq!(options.initial_indent, "######");
+        assert_eq!(options.subsequent_indent, "");
     }
 
     #[test]


### PR DESCRIPTION
This fixes two bugs in `unfill`, both to do with the way we were slicing strings in cases where the input ended with a combination of `\r` and `\n`.

Fixes #466.