### PR TITLE
Remove redundant `if:` braces

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -35,7 +35,7 @@ jobs:
 
   pull-request:
     needs: setup
-    if: ${{ needs.setup.outputs.old-version != needs.setup.outputs.new-version }}
+    if: needs.setup.outputs.old-version != needs.setup.outputs.new-version
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository


### PR DESCRIPTION
As per the GitHub Action documentation, the value of an `if:` is already evaluated as an expression.