### PR TITLE
Add fast paths to `fill` and `wrap`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,6 +112,7 @@ jobs:
         fuzz-target:
           - fill_first_fit
           - fill_optimal_fit
+          - fill_fast_path
           - wrap_first_fit
           - wrap_optimal_fit
           - wrap_optimal_fit_usize

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,6 +116,7 @@ jobs:
           - wrap_first_fit
           - wrap_optimal_fit
           - wrap_optimal_fit_usize
+          - wrap_fast_path
           - unfill
           - refill
 

--- a/benchmarks/linear.rs
+++ b/benchmarks/linear.rs
@@ -27,12 +27,13 @@ pub fn benchmark(c: &mut Criterion) {
     ];
     for length in lengths {
         let text = lorem_ipsum(length);
+        let length_id = format!("{length:04}");
 
         let options = textwrap::Options::new(LINE_LENGTH)
             .wrap_algorithm(textwrap::WrapAlgorithm::new_optimal_fit())
             .word_separator(textwrap::WordSeparator::UnicodeBreakProperties);
         group.bench_with_input(
-            BenchmarkId::new("fill_optimal_fit_unicode", length),
+            BenchmarkId::new("fill_optimal_fit_unicode", &length_id),
             &text,
             |b, text| {
                 b.iter(|| textwrap::fill(text, &options));
@@ -43,7 +44,7 @@ pub fn benchmark(c: &mut Criterion) {
             .wrap_algorithm(textwrap::WrapAlgorithm::new_optimal_fit())
             .word_separator(textwrap::WordSeparator::AsciiSpace);
         group.bench_with_input(
-            BenchmarkId::new("fill_optimal_fit_ascii", length),
+            BenchmarkId::new("fill_optimal_fit_ascii", &length_id),
             &text,
             |b, text| {
                 b.iter(|| textwrap::fill(text, &options));
@@ -54,14 +55,14 @@ pub fn benchmark(c: &mut Criterion) {
             .wrap_algorithm(textwrap::WrapAlgorithm::FirstFit)
             .word_separator(textwrap::WordSeparator::AsciiSpace);
         group.bench_with_input(
-            BenchmarkId::new("fill_first_fit", length),
+            BenchmarkId::new("fill_first_fit", &length_id),
             &text,
             |b, text| {
                 b.iter(|| textwrap::fill(text, &options));
             },
         );
 
-        group.bench_function(BenchmarkId::new("fill_inplace", length), |b| {
+        group.bench_function(BenchmarkId::new("fill_inplace", &length_id), |b| {
             b.iter_batched(
                 || text.clone(),
                 |mut text| textwrap::fill_inplace(&mut text, LINE_LENGTH),
@@ -77,7 +78,7 @@ pub fn benchmark(c: &mut Criterion) {
             .word_separator(textwrap::WordSeparator::AsciiSpace)
             .word_splitter(textwrap::WordSplitter::Hyphenation(dictionary));
         group.bench_with_input(
-            BenchmarkId::new("fill_optimal_fit_ascii_hyphenation", length),
+            BenchmarkId::new("fill_optimal_fit_ascii_hyphenation", &length_id),
             &text,
             |b, text| {
                 b.iter(|| textwrap::fill(text, &options));

--- a/benchmarks/linear.rs
+++ b/benchmarks/linear.rs
@@ -21,7 +21,11 @@ fn lorem_ipsum(length: usize) -> String {
 
 pub fn benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("String lengths");
-    for length in [200, 300, 400, 600, 800, 1200, 1600, 2400, 3200, 4800, 6400] {
+    let lengths = [
+        0, 5, 10, 20, 30, 40, 50, 60, 80, 100, 200, 300, 400, 600, 800, 1200, 1600, 2400, 3200,
+        4800, 6400,
+    ];
+    for length in lengths {
         let text = lorem_ipsum(length);
 
         let options = textwrap::Options::new(LINE_LENGTH)

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -59,3 +59,9 @@ name = "unfill"
 path = "fuzz_targets/unfill.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "fill_fast_path"
+path = "fuzz_targets/fill_fast_path.rs"
+test = false
+doc = false

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -65,3 +65,9 @@ name = "fill_fast_path"
 path = "fuzz_targets/fill_fast_path.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "wrap_fast_path"
+path = "fuzz_targets/wrap_fast_path.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/fill_fast_path.rs
+++ b/fuzz/fuzz_targets/fill_fast_path.rs
@@ -1,0 +1,10 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|input: (String, usize)| {
+    let options = textwrap::Options::new(input.1);
+    let fast = textwrap::fill(&input.0, &options);
+    # fill_slow_path_for_fuzzing is exposed due to --cfg fuzzing.
+    let slow = textwrap::fill_slow_path_for_fuzzing(&input.0, options);
+    assert_eq!(fast, slow);
+});

--- a/fuzz/fuzz_targets/fill_fast_path.rs
+++ b/fuzz/fuzz_targets/fill_fast_path.rs
@@ -4,7 +4,6 @@ use libfuzzer_sys::fuzz_target;
 fuzz_target!(|input: (String, usize)| {
     let options = textwrap::Options::new(input.1);
     let fast = textwrap::fill(&input.0, &options);
-    # fill_slow_path_for_fuzzing is exposed due to --cfg fuzzing.
-    let slow = textwrap::fill_slow_path_for_fuzzing(&input.0, options);
+    let slow = textwrap::fuzzing::fill_slow_path(&input.0, options);
     assert_eq!(fast, slow);
 });

--- a/fuzz/fuzz_targets/wrap_fast_path.rs
+++ b/fuzz/fuzz_targets/wrap_fast_path.rs
@@ -1,0 +1,17 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|input: (String, usize)| {
+    // Filter out multi-line input.
+    if input.0.contains('\n') {
+        return;
+    }
+
+    let mut fast = Vec::new();
+    let mut slow = Vec::new();
+
+    let options = textwrap::Options::new(input.1);
+    textwrap::wrap_single_line_for_fuzzing(&input.0, &options, &mut fast);
+    textwrap::wrap_single_line_slow_path_for_fuzzing(&input.0, &options, &mut slow);
+    assert_eq!(fast, slow);
+});

--- a/fuzz/fuzz_targets/wrap_fast_path.rs
+++ b/fuzz/fuzz_targets/wrap_fast_path.rs
@@ -11,7 +11,7 @@ fuzz_target!(|input: (String, usize)| {
     let mut slow = Vec::new();
 
     let options = textwrap::Options::new(input.1);
-    textwrap::wrap_single_line_for_fuzzing(&input.0, &options, &mut fast);
-    textwrap::wrap_single_line_slow_path_for_fuzzing(&input.0, &options, &mut slow);
+    textwrap::fuzzing::wrap_single_line(&input.0, &options, &mut fast);
+    textwrap::fuzzing::wrap_single_line_slow_path(&input.0, &options, &mut slow);
     assert_eq!(fast, slow);
 });

--- a/src/fuzzing.rs
+++ b/src/fuzzing.rs
@@ -1,0 +1,23 @@
+//! Fuzzing helpers.
+
+use super::Options;
+use std::borrow::Cow;
+
+/// Exposed for fuzzing so we can check the slow path is correct.
+pub fn fill_slow_path<'a>(text: &str, options: Options<'_>) -> String {
+    super::fill_slow_path(text, options)
+}
+
+/// Exposed for fuzzing so we can check the slow path is correct.
+pub fn wrap_single_line<'a>(line: &'a str, options: &Options<'_>, lines: &mut Vec<Cow<'a, str>>) {
+    super::wrap_single_line(line, options, lines);
+}
+
+/// Exposed for fuzzing so we can check the slow path is correct.
+pub fn wrap_single_line_slow_path<'a>(
+    line: &'a str,
+    options: &Options<'_>,
+    lines: &mut Vec<Cow<'a, str>>,
+) {
+    super::wrap_single_line_slow_path(line, options, lines)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,6 +223,11 @@ pub use line_ending::LineEnding;
 
 pub mod core;
 
+// This module is only active when running fuzz tests. It provides
+// access to private helpers.
+#[cfg(fuzzing)]
+pub mod fuzzing;
+
 /// Holds configuration options for wrapping and filling text.
 #[derive(Debug, Clone)]
 pub struct Options<'a> {
@@ -613,12 +618,6 @@ where
     }
 }
 
-/// Exposed for fuzzing so we can check the slow path is correct.
-#[cfg(fuzzing)]
-pub fn fill_slow_path_for_fuzzing<'a>(text: &str, options: Options<'_>) -> String {
-    fill_slow_path(text, options)
-}
-
 /// Slow path for fill.
 ///
 /// This is taken when `text` is longer than `options.width`.
@@ -1007,16 +1006,6 @@ where
     lines
 }
 
-/// Exposed for fuzzing so we can check the slow path is correct.
-#[cfg(fuzzing)]
-pub fn wrap_single_line_for_fuzzing<'a>(
-    line: &'a str,
-    options: &Options<'_>,
-    lines: &mut Vec<Cow<'a, str>>,
-) {
-    wrap_single_line(line, options, lines);
-}
-
 fn wrap_single_line<'a>(line: &'a str, options: &Options<'_>, lines: &mut Vec<Cow<'a, str>>) {
     let indent = if lines.is_empty() {
         options.initial_indent
@@ -1028,16 +1017,6 @@ fn wrap_single_line<'a>(line: &'a str, options: &Options<'_>, lines: &mut Vec<Co
     } else {
         wrap_single_line_slow_path(line, options, lines)
     }
-}
-
-/// Exposed for fuzzing so we can check the slow path is correct.
-#[cfg(fuzzing)]
-pub fn wrap_single_line_slow_path_for_fuzzing<'a>(
-    line: &'a str,
-    options: &Options<'_>,
-    lines: &mut Vec<Cow<'a, str>>,
-) {
-    wrap_single_line_slow_path(line, options, lines)
 }
 
 /// Wrap a single line of text.


### PR DESCRIPTION
In case the input is shorter than the wrapping width, we can return it immediately. This avoids findings words, breaking them, and finally reassembling them.

The speedup from the is on the order of 10-25 times, depending on the wrapping width. I tested with a wrapping width of 60 columns and there the time for `fill("")` is now around 15 nanoseconds. It was around 150 nanoseconds before:

```
String lengths/fill_first_fit/0000
                        time:   [15.843 ns 15.880 ns 15.936 ns]
                        change: [-90.123% -90.066% -90.003%] (p = 0.00 < 0.05)
                        Performance has improved.
```

A similar 10x improvement is seen for `fill("abcde")`:
```
String lengths/fill_first_fit/0005
                        time:   [28.256 ns 28.311 ns 28.385 ns]
                        change: [-90.482% -90.428% -90.373%] (p = 0.00 < 0.05)
                        Performance has improved.
```

As strings get longer and closer to the wrapping width, the improvements get larger. Before it took just shy of a microsecond to wrap a 50 character string on my machine:

```
String lengths/fill_first_fit/0050
                        time:   [943.91 ns 944.96 ns 946.17 ns]
```
Now it only takes 34 nanoseconds, a 27x improvement:
```
String lengths/fill_first_fit/0050
                        time:   [34.438 ns 34.506 ns 34.586 ns]
                        change: [-96.362% -96.336% -96.306%] (p = 0.00 < 0.05)
                        Performance has improved.
```

The time needed to wrap the input is nearly flat until you hit the wrapping width, as which time it grows linearly with the input length:

![image](https://user-images.githubusercontent.com/89623/193426831-65fc2c00-a277-4c83-9876-0011904f8d60.png)


