### PR TITLE
Also derive `Eq` for `Penalties`

### DIFF
--- a/src/wrap_algorithms/optimal_fit.rs
+++ b/src/wrap_algorithms/optimal_fit.rs
@@ -19,7 +19,7 @@ use crate::core::Fragment;
 ///
 /// **Note:** Only available when the `smawk` Cargo feature is
 /// enabled.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Penalties {
     /// Per-line penalty. This is added for every line, which makes it
     /// expensive to output more lines than the minimum required.


### PR DESCRIPTION
This is from `clippy::derive_partial_eq_without_eq`. The lint has known false positives and has been moved to the nursery on the nightly compiler, though it seems okay in this case:

  https://github.com/rust-lang/rust-clippy/issues/9530
