### PR TITLE
Limit inputs to prevent OSS-Fuzz timeouts

### DIFF
--- a/fuzz/fuzz_targets/fill_fast_path.rs
+++ b/fuzz/fuzz_targets/fill_fast_path.rs
@@ -2,6 +2,10 @@
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|input: (String, usize)| {
+    if input.0.len() > 100_000 {
+        return; // Avoid timeouts in OSS-Fuzz.
+    }
+
     let options = textwrap::Options::new(input.1);
     let fast = textwrap::fill(&input.0, &options);
     let slow = textwrap::fuzzing::fill_slow_path(&input.0, options);

--- a/fuzz/fuzz_targets/fill_first_fit.rs
+++ b/fuzz/fuzz_targets/fill_first_fit.rs
@@ -4,6 +4,10 @@ use textwrap::Options;
 use textwrap::WrapAlgorithm;
 
 fuzz_target!(|input: (String, usize)| {
+    if input.0.len() > 100_000 {
+        return; // Avoid timeouts in OSS-Fuzz.
+    }
+
     let options = Options::new(input.1).wrap_algorithm(WrapAlgorithm::FirstFit);
     let _ = textwrap::fill(&input.0, &options);
 });

--- a/fuzz/fuzz_targets/fill_optimal_fit.rs
+++ b/fuzz/fuzz_targets/fill_optimal_fit.rs
@@ -4,6 +4,10 @@ use textwrap::Options;
 use textwrap::WrapAlgorithm;
 
 fuzz_target!(|input: (String, usize)| {
+    if input.0.len() > 100_000 {
+        return; // Avoid timeouts in OSS-Fuzz.
+    }
+
     let options = Options::new(input.1).wrap_algorithm(WrapAlgorithm::new_optimal_fit());
     let _ = textwrap::fill(&input.0, &options);
 });

--- a/fuzz/fuzz_targets/refill.rs
+++ b/fuzz/fuzz_targets/refill.rs
@@ -2,5 +2,9 @@
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|input: (String, usize)| {
+    if input.0.len() > 100_000 {
+        return; // Avoid timeouts in OSS-Fuzz.
+    }
+
     let _ = textwrap::refill(&input.0, input.1);
 });

--- a/fuzz/fuzz_targets/unfill.rs
+++ b/fuzz/fuzz_targets/unfill.rs
@@ -2,5 +2,9 @@
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|input: String| {
+    if input.len() > 100_000 {
+        return; // Avoid timeouts in OSS-Fuzz.
+    }
+
     let _ = textwrap::unfill(&input);
 });

--- a/fuzz/fuzz_targets/wrap_fast_path.rs
+++ b/fuzz/fuzz_targets/wrap_fast_path.rs
@@ -2,15 +2,17 @@
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|input: (String, usize)| {
-    // Filter out multi-line input.
-    if input.0.contains('\n') {
-        return;
+    if input.0.len() > 100_000 {
+        return; // Avoid timeouts in OSS-Fuzz.
     }
 
-    let mut fast = Vec::new();
-    let mut slow = Vec::new();
+    if input.0.contains('\n') {
+        return; // Filter out multi-line input.
+    }
 
     let options = textwrap::Options::new(input.1);
+    let mut fast = Vec::new();
+    let mut slow = Vec::new();
     textwrap::fuzzing::wrap_single_line(&input.0, &options, &mut fast);
     textwrap::fuzzing::wrap_single_line_slow_path(&input.0, &options, &mut slow);
     assert_eq!(fast, slow);


### PR DESCRIPTION
I downloaded the failing test cases from OSS-Fuzz and ran the fuzzers on each of them: they all finished in ~35 seconds on my laptop. The timeout on OSS-Fuzz is 25 seconds, which explains the timeouts.

![image](https://user-images.githubusercontent.com/89623/198871495-734c55dd-b3e6-481e-9954-19eb507d3516.png)

Limiting the input length to 100k bytes should help here and still allow us to test all reasonable inputs.