### PR TITLE
Add `tab_width` support

### DIFF
--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -23,6 +23,11 @@ name = "unfill"
 harness = false
 path = "unfill.rs"
 
+[[bench]]
+name = "display_width"
+harness = false
+path = "display_width.rs"
+
 [dependencies]
 textwrap = { path = "../", features = ["hyphenation"] }
 

--- a/benchmarks/display_width.rs
+++ b/benchmarks/display_width.rs
@@ -1,0 +1,26 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+
+pub fn benchmark(c: &mut Criterion) {
+    let words_per_line = [
+        5, 10, 15, 5, 5, 10, 5, 5, 5, 10, // 10 lines
+        10, 10, 5, 5, 5, 5, 15, 10, 5, 5, // 20 lines
+        10, 5, 5, 5, 15, 10, 10, 5, 5, 5, // 30 lines
+        15, 5, 5, 10, 5, 5, 5, 15, 5, 10, // 40 lines
+        5, 15, 5, 5, 15, 5, 10, 10, 5, 5, // 50 lines
+    ];
+    let mut text = String::new();
+    for (line_no, word_count) in words_per_line.iter().enumerate() {
+        text.push_str("\t\t\t");
+        text.push_str(&lipsum::lipsum_words_from_seed(*word_count, line_no as u64));
+        text.push('\n');
+    }
+    text.push_str("\n\n\n\n");
+    assert_eq!(text.len(), 2800); // The size for reference.
+
+    c.bench_function("display_width", |b| {
+        b.iter(|| textwrap::core::display_width(&text, 2))
+    });
+}
+
+criterion_group!(benches, benchmark);
+criterion_main!(benches);

--- a/examples/wasm/src/lib.rs
+++ b/examples/wasm/src/lib.rs
@@ -152,7 +152,7 @@ impl textwrap::core::Fragment for CanvasWord<'_> {
     }
 
     #[inline]
-    fn whitespace_width(&self) -> f64 {
+    fn whitespace_width(&self, _: u8) -> f64 {
         self.whitespace_width
     }
 
@@ -351,7 +351,7 @@ pub fn draw_wrapped_text(
     let mut lineno = 0;
     for line in text.split('\n') {
         let words = word_separator.find_words(line);
-        let split_words = split_words(words, &word_splitter);
+        let split_words = split_words(words, &word_splitter, 0);
 
         let canvas_words = split_words
             .flat_map(|word| {
@@ -366,10 +366,10 @@ pub fn draw_wrapped_text(
 
         let line_lengths = [options.width];
         let wrapped_words = match options.wrap_algorithm {
-            WasmWrapAlgorithm::FirstFit => wrap_first_fit(&canvas_words, &line_lengths),
+            WasmWrapAlgorithm::FirstFit => wrap_first_fit(&canvas_words, &line_lengths, 0),
             WasmWrapAlgorithm::OptimalFit => {
                 let penalties = options.penalties.into();
-                wrap_optimal_fit(&canvas_words, &line_lengths, &penalties).unwrap()
+                wrap_optimal_fit(&canvas_words, &line_lengths, 0, &penalties).unwrap()
             }
             _ => Err("WasmOptions has an invalid wrap_algorithm field")?,
         };

--- a/fuzz/fuzz_targets/wrap_first_fit.rs
+++ b/fuzz/fuzz_targets/wrap_first_fit.rs
@@ -14,12 +14,12 @@ struct Word {
 #[rustfmt::skip]
 impl core::Fragment for Word {
     fn width(&self) -> f64 { self.width }
-    fn whitespace_width(&self) -> f64 { self.whitespace_width }
+    fn whitespace_width(&self, _: u8) -> f64 { self.whitespace_width }
     fn penalty_width(&self) -> f64 { self.penalty_width }
 }
 
 fuzz_target!(|input: (f64, Vec<Word>)| {
     let width = input.0;
     let words = input.1;
-    let _ = wrap_first_fit(&words, &[width]);
+    let _ = wrap_first_fit(&words, &[width], 0);
 });

--- a/fuzz/fuzz_targets/wrap_optimal_fit.rs
+++ b/fuzz/fuzz_targets/wrap_optimal_fit.rs
@@ -35,7 +35,7 @@ struct Word {
 #[rustfmt::skip]
 impl core::Fragment for Word {
     fn width(&self) -> f64 { self.width }
-    fn whitespace_width(&self) -> f64 { self.whitespace_width }
+    fn whitespace_width(&self, _: u8) -> f64 { self.whitespace_width }
     fn penalty_width(&self) -> f64 { self.penalty_width }
 }
 
@@ -57,5 +57,5 @@ fuzz_target!(|input: (usize, Vec<Word>, Penalties)| {
         }
     }
 
-    let _ = wrap_optimal_fit(&words, &[width as f64], &penalties);
+    let _ = wrap_optimal_fit(&words, &[width as f64], 0, &penalties);
 });

--- a/fuzz/fuzz_targets/wrap_optimal_fit_usize.rs
+++ b/fuzz/fuzz_targets/wrap_optimal_fit_usize.rs
@@ -35,7 +35,7 @@ struct Word {
 #[rustfmt::skip]
 impl core::Fragment for Word {
     fn width(&self) -> f64 { self.width as f64 }
-    fn whitespace_width(&self) -> f64 { self.whitespace_width as f64 }
+    fn whitespace_width(&self, _: u8) -> f64 { self.whitespace_width as f64 }
     fn penalty_width(&self) -> f64 { self.penalty_width as f64 }
 }
 
@@ -45,5 +45,5 @@ fuzz_target!(|input: (usize, Vec<Word>, Penalties)| {
     let width = input.0;
     let words = input.1;
     let penalties = input.2.into();
-    let _ = wrap_optimal_fit(&words, &[width as f64], &penalties);
+    let _ = wrap_optimal_fit(&words, &[width as f64], 0, &penalties);
 });

--- a/src/core.rs
+++ b/src/core.rs
@@ -61,8 +61,12 @@ pub(crate) fn skip_ansi_escape_sequence<I: Iterator<Item = char>>(ch: char, char
 
 #[cfg(feature = "unicode-width")]
 #[inline]
-fn ch_width(ch: char) -> usize {
-    unicode_width::UnicodeWidthChar::width(ch).unwrap_or(0)
+fn ch_width(ch: char, tab_width: u8) -> usize {
+    if ch == '\t' {
+        tab_width as usize
+    } else {
+        unicode_width::UnicodeWidthChar::width(ch).unwrap_or(0)
+    }
 }
 
 /// First character which [`ch_width`] will classify as double-width.
@@ -72,8 +76,10 @@ const DOUBLE_WIDTH_CUTOFF: char = '\u{1100}';
 
 #[cfg(not(feature = "unicode-width"))]
 #[inline]
-fn ch_width(ch: char) -> usize {
-    if ch < DOUBLE_WIDTH_CUTOFF {
+fn ch_width(ch: char, tab_width: u8) -> usize {
+    if ch == '\t' {
+        tab_width as usize
+    } else if ch < DOUBLE_WIDTH_CUTOFF {
         1
     } else {
         2
@@ -88,8 +94,8 @@ fn ch_width(ch: char) -> usize {
 /// ```
 /// use textwrap::core::display_width;
 ///
-/// assert_eq!(display_width("Café Plain"), 10);
-/// assert_eq!(display_width("\u{1b}[31mCafé Rouge\u{1b}[0m"), 10);
+/// assert_eq!(display_width("Café Plain", 0), 10);
+/// assert_eq!(display_width("\u{1b}[31mCafé Rouge\u{1b}[0m", 0), 10);
 /// ```
 ///
 /// **Note:** When the `unicode-width` Cargo feature is disabled, the
@@ -107,11 +113,11 @@ fn ch_width(ch: char) -> usize {
 /// ```
 /// use textwrap::core::display_width;
 ///
-/// assert_eq!(display_width("Cafe Plain"), 10);
+/// assert_eq!(display_width("Cafe Plain", 0), 10);
 /// #[cfg(feature = "unicode-width")]
-/// assert_eq!(display_width("Cafe\u{301} Plain"), 10);
+/// assert_eq!(display_width("Cafe\u{301} Plain", 0), 10);
 /// #[cfg(not(feature = "unicode-width"))]
-/// assert_eq!(display_width("Cafe\u{301} Plain"), 11);
+/// assert_eq!(display_width("Cafe\u{301} Plain", 0), 11);
 /// ```
 ///
 /// ## Emojis and CJK Characters
@@ -123,8 +129,8 @@ fn ch_width(ch: char) -> usize {
 /// ```
 /// use textwrap::core::display_width;
 ///
-/// assert_eq!(display_width("😂😭🥺🤣✨😍🙏🥰😊🔥"), 20);
-/// assert_eq!(display_width("你好"), 4);  // “Nǐ hǎo” or “Hello” in Chinese
+/// assert_eq!(display_width("😂😭🥺🤣✨😍🙏🥰😊🔥", 0), 20);
+/// assert_eq!(display_width("你好", 0), 4);  // “Nǐ hǎo” or “Hello” in Chinese
 /// ```
 ///
 /// # Limitations
@@ -150,9 +156,9 @@ fn ch_width(ch: char) -> usize {
 ///
 /// assert_eq!("👨‍🦰".chars().collect::<Vec<char>>(), ['\u{1f468}', '\u{200d}', '\u{1f9b0}']);
 /// #[cfg(feature = "unicode-width")]
-/// assert_eq!(display_width("👨‍🦰"), 4);
+/// assert_eq!(display_width("👨‍🦰", 0), 4);
 /// #[cfg(not(feature = "unicode-width"))]
-/// assert_eq!(display_width("👨‍🦰"), 6);
+/// assert_eq!(display_width("👨‍🦰", 0), 6);
 /// ```
 ///
 /// This happens because the grapheme consists of three code points:
@@ -172,14 +178,14 @@ fn ch_width(ch: char) -> usize {
 /// [Unicode equivalence]: https://en.wikipedia.org/wiki/Unicode_equivalence
 /// [CJK characters]: https://en.wikipedia.org/wiki/CJK_characters
 /// [emoji modifier sequences]: https://unicode.org/emoji/charts/full-emoji-modifiers.html
-pub fn display_width(text: &str) -> usize {
+pub fn display_width(text: &str, tab_width: u8) -> usize {
     let mut chars = text.chars();
     let mut width = 0;
     while let Some(ch) = chars.next() {
         if skip_ansi_escape_sequence(ch, &mut chars) {
             continue;
         }
-        width += ch_width(ch);
+        width += ch_width(ch, tab_width);
     }
     width
 }
@@ -200,7 +206,7 @@ pub trait Fragment: std::fmt::Debug {
 
     /// Displayed width of the whitespace that must follow the word
     /// when the word is not at the end of a line.
-    fn whitespace_width(&self) -> f64;
+    fn whitespace_width(&self, tab_width: u8) -> f64;
 
     /// Displayed width of the penalty that must be inserted if the
     /// word falls at the end of a line.
@@ -234,13 +240,15 @@ impl std::ops::Deref for Word<'_> {
 impl<'a> Word<'a> {
     /// Construct a `Word` from a string.
     ///
-    /// A trailing stretch of `' '` is automatically taken to be the
-    /// whitespace part of the word.
+    /// All trailing whitespace is automatically taken to be the whitespace part
+    /// of the word.
     pub fn from(word: &str) -> Word<'_> {
-        let trimmed = word.trim_end_matches(' ');
+        let trimmed = word.trim_end_matches(&[' ', '\t']);
         Word {
             word: trimmed,
-            width: display_width(trimmed),
+            // trimmed shouldn't contain whitespace, so we don't need to pass
+            // an accurate tab_width.
+            width: display_width(trimmed, 0),
             whitespace: &word[trimmed.len()..],
             penalty: "",
         }
@@ -255,11 +263,15 @@ impl<'a> Word<'a> {
     /// ```
     /// use textwrap::core::Word;
     /// assert_eq!(
-    ///     Word::from("Hello!  ").break_apart(3).collect::<Vec<_>>(),
+    ///     Word::from("Hello!  ").break_apart(3, 0).collect::<Vec<_>>(),
     ///     vec![Word::from("Hel"), Word::from("lo!  ")]
     /// );
     /// ```
-    pub fn break_apart<'b>(&'b self, line_width: usize) -> impl Iterator<Item = Word<'a>> + 'b {
+    pub fn break_apart<'b>(
+        &'b self,
+        line_width: usize,
+        tab_width: u8,
+    ) -> impl Iterator<Item = Word<'a>> + 'b {
         let mut char_indices = self.word.char_indices();
         let mut offset = 0;
         let mut width = 0;
@@ -270,27 +282,26 @@ impl<'a> Word<'a> {
                     continue;
                 }
 
-                if width > 0 && width + ch_width(ch) > line_width {
+                if width > 0 && width + ch_width(ch, tab_width) > line_width {
                     let word = Word {
                         word: &self.word[offset..idx],
-                        width: width,
                         whitespace: "",
                         penalty: "",
+                        width,
                     };
                     offset = idx;
-                    width = ch_width(ch);
+                    width = ch_width(ch, tab_width);
                     return Some(word);
                 }
 
-                width += ch_width(ch);
+                width += ch_width(ch, tab_width);
             }
 
             if offset < self.word.len() {
                 let word = Word {
                     word: &self.word[offset..],
-                    width: width,
-                    whitespace: self.whitespace,
-                    penalty: self.penalty,
+                    width,
+                    ..*self
                 };
                 offset = self.word.len();
                 return Some(word);
@@ -307,11 +318,9 @@ impl Fragment for Word<'_> {
         self.width as f64
     }
 
-    // We assume the whitespace consist of ' ' only. This allows us to
-    // compute the display width in constant time.
     #[inline]
-    fn whitespace_width(&self) -> f64 {
-        self.whitespace.len() as f64
+    fn whitespace_width(&self, tab_width: u8) -> f64 {
+        display_width(self.whitespace, tab_width) as f64
     }
 
     // We assume the penalty is `""` or `"-"`. This allows us to
@@ -327,14 +336,14 @@ impl Fragment for Word<'_> {
 /// This simply calls [`Word::break_apart`] on words that are too
 /// wide. This means that no extra `'-'` is inserted, the word is
 /// simply broken into smaller pieces.
-pub fn break_words<'a, I>(words: I, line_width: usize) -> Vec<Word<'a>>
+pub fn break_words<'a, I>(words: I, line_width: usize, tab_width: u8) -> Vec<Word<'a>>
 where
     I: IntoIterator<Item = Word<'a>>,
 {
     let mut shortened_words = Vec::new();
     for word in words {
         if word.width() > line_width as f64 {
-            shortened_words.extend(word.break_apart(line_width));
+            shortened_words.extend(word.break_apart(line_width, tab_width));
         } else {
             shortened_words.push(word);
         }
@@ -373,7 +382,7 @@ mod tests {
                 assert_eq!(ch.width().unwrap(), 1, "char: {}", desc);
 
                 #[cfg(not(feature = "unicode-width"))]
-                assert_eq!(ch_width(ch), 1, "char: {}", desc);
+                assert_eq!(ch_width(ch, 0), 1, "char: {}", desc);
             }
         }
 
@@ -391,7 +400,7 @@ mod tests {
                 assert!(ch.width().unwrap() <= 2, "char: {}", desc);
 
                 #[cfg(not(feature = "unicode-width"))]
-                assert_eq!(ch_width(ch), 2, "char: {}", desc);
+                assert_eq!(ch_width(ch, 0), 2, "char: {}", desc);
             }
         }
 
@@ -402,32 +411,32 @@ mod tests {
     #[test]
     fn display_width_works() {
         assert_eq!("Café Plain".len(), 11); // “é” is two bytes
-        assert_eq!(display_width("Café Plain"), 10);
-        assert_eq!(display_width("\u{1b}[31mCafé Rouge\u{1b}[0m"), 10);
+        assert_eq!(display_width("Café Plain", 0), 10);
+        assert_eq!(display_width("\u{1b}[31mCafé Rouge\u{1b}[0m", 0), 10);
     }
 
     #[test]
     fn display_width_narrow_emojis() {
         #[cfg(feature = "unicode-width")]
-        assert_eq!(display_width("⁉"), 1);
+        assert_eq!(display_width("⁉", 0), 1);
 
         // The ⁉ character is above DOUBLE_WIDTH_CUTOFF.
         #[cfg(not(feature = "unicode-width"))]
-        assert_eq!(display_width("⁉"), 2);
+        assert_eq!(display_width("⁉", 0), 2);
     }
 
     #[test]
     fn display_width_narrow_emojis_variant_selector() {
         #[cfg(feature = "unicode-width")]
-        assert_eq!(display_width("⁉\u{fe0f}"), 1);
+        assert_eq!(display_width("⁉\u{fe0f}", 0), 1);
 
         // The variant selector-16 is also counted.
         #[cfg(not(feature = "unicode-width"))]
-        assert_eq!(display_width("⁉\u{fe0f}"), 4);
+        assert_eq!(display_width("⁉\u{fe0f}", 0), 4);
     }
 
     #[test]
     fn display_width_emojis() {
-        assert_eq!(display_width("😂😭🥺🤣✨😍🙏🥰😊🔥"), 20);
+        assert_eq!(display_width("😂😭🥺🤣✨😍🙏🥰😊🔥", 0), 20);
     }
 }

--- a/src/options.rs
+++ b/src/options.rs
@@ -8,6 +8,8 @@ use crate::{LineEnding, WordSeparator, WordSplitter, WrapAlgorithm};
 pub struct Options<'a> {
     /// The width in columns at which the text will be wrapped.
     pub width: usize,
+    /// How wide a tab character should be considered to be.
+    pub tab_width: u8,
     /// Line ending used for breaking lines.
     pub line_ending: LineEnding,
     /// Indentation used for the first line of output. See the
@@ -36,6 +38,7 @@ impl<'a> From<&'a Options<'a>> for Options<'a> {
     fn from(options: &'a Options<'a>) -> Self {
         Self {
             width: options.width,
+            tab_width: options.tab_width,
             line_ending: options.line_ending,
             initial_indent: options.initial_indent,
             subsequent_indent: options.subsequent_indent,
@@ -86,6 +89,7 @@ impl<'a> Options<'a> {
     pub const fn new(width: usize) -> Self {
         Options {
             width,
+            tab_width: 0,
             line_ending: LineEnding::LF,
             initial_indent: "",
             subsequent_indent: "",
@@ -116,6 +120,26 @@ impl<'a> Options<'a> {
             line_ending,
             ..self
         }
+    }
+
+    /// Change [`self.tab_width`]. The tab width is how wide
+    /// a tab character should be considered. By default, a tab
+    /// character to be consiered to have a width of 0.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use textwrap::{Options, wrap};
+    ///
+    /// assert_eq!(wrap("foo\tbar baz", Options::new(12).tab_width(0)),
+    ///     vec!["foo\tbar baz"]);
+    /// assert_eq!(wrap("foo\tbar baz", Options::new(12).tab_width(4)),
+    ///     vec!["foo\tbar", "baz"]);
+    /// ```
+    ///
+    /// [`self.tab_width`]: #structfield.tab_width
+    pub fn tab_width(self, tab_width: u8) -> Self {
+        Options { tab_width, ..self }
     }
 
     /// Change [`self.initial_indent`]. The initial indentation is
@@ -217,6 +241,7 @@ impl<'a> Options<'a> {
     pub fn word_separator(self, word_separator: WordSeparator) -> Options<'a> {
         Options {
             width: self.width,
+            tab_width: self.tab_width,
             line_ending: self.line_ending,
             initial_indent: self.initial_indent,
             subsequent_indent: self.subsequent_indent,
@@ -235,6 +260,7 @@ impl<'a> Options<'a> {
     pub fn wrap_algorithm(self, wrap_algorithm: WrapAlgorithm) -> Options<'a> {
         Options {
             width: self.width,
+            tab_width: self.tab_width,
             line_ending: self.line_ending,
             initial_indent: self.initial_indent,
             subsequent_indent: self.subsequent_indent,
@@ -279,6 +305,7 @@ impl<'a> Options<'a> {
     pub fn word_splitter(self, word_splitter: WordSplitter) -> Options<'a> {
         Options {
             width: self.width,
+            tab_width: self.tab_width,
             line_ending: self.line_ending,
             initial_indent: self.initial_indent,
             subsequent_indent: self.subsequent_indent,

--- a/src/refill.rs
+++ b/src/refill.rs
@@ -60,11 +60,11 @@ use crate::{fill, LineEnding, Options};
 /// assert_eq!(options.line_ending, LineEnding::LF);
 /// ```
 pub fn unfill(text: &str) -> (String, Options<'_>) {
-    let prefix_chars: &[_] = &[' ', '-', '+', '*', '>', '#', '/'];
+    let prefix_chars: &[_] = &[' ', '\t', '-', '+', '*', '>', '#', '/'];
 
     let mut options = Options::new(0);
     for (idx, line) in text.lines().enumerate() {
-        options.width = std::cmp::max(options.width, display_width(line));
+        options.width = std::cmp::max(options.width, display_width(line, options.tab_width));
         let without_prefix = line.trim_start_matches(prefix_chars);
         let prefix = &line[..line.len() - without_prefix.len()];
 

--- a/src/wrap_algorithms.rs
+++ b/src/wrap_algorithms.rs
@@ -168,6 +168,7 @@ impl WrapAlgorithm {
         &self,
         words: &'b [Word<'a>],
         line_widths: &'b [usize],
+        tab_width: u8,
     ) -> Vec<&'b [Word<'a>]> {
         // Every integer up to 2u64.pow(f64::MANTISSA_DIGITS) = 2**53
         // = 9_007_199_254_740_992 can be represented without loss by
@@ -176,13 +177,13 @@ impl WrapAlgorithm {
         let f64_line_widths = line_widths.iter().map(|w| *w as f64).collect::<Vec<_>>();
 
         match self {
-            WrapAlgorithm::FirstFit => wrap_first_fit(words, &f64_line_widths),
+            WrapAlgorithm::FirstFit => wrap_first_fit(words, &f64_line_widths, tab_width),
 
             #[cfg(feature = "smawk")]
             WrapAlgorithm::OptimalFit(penalties) => {
                 // The computation cannnot overflow when the line
                 // widths are restricted to usize.
-                wrap_optimal_fit(words, &f64_line_widths, penalties).unwrap()
+                wrap_optimal_fit(words, &f64_line_widths, tab_width, penalties).unwrap()
             }
 
             WrapAlgorithm::Custom(func) => func(words, line_widths),
@@ -231,7 +232,7 @@ impl Default for WrapAlgorithm {
 ///
 /// let text = "These few words will unfortunately not wrap nicely.";
 /// let words = WordSeparator::AsciiSpace.find_words(text).collect::<Vec<_>>();
-/// assert_eq!(lines_to_strings(wrap_first_fit(&words, &[15.0])),
+/// assert_eq!(lines_to_strings(wrap_first_fit(&words, &[15.0], 0)),
 ///            vec!["These few words",
 ///                 "will",  // <-- short line
 ///                 "unfortunately",
@@ -242,7 +243,7 @@ impl Default for WrapAlgorithm {
 /// #[cfg(feature = "smawk")]
 /// use textwrap::wrap_algorithms::{wrap_optimal_fit, Penalties};
 /// #[cfg(feature = "smawk")]
-/// assert_eq!(lines_to_strings(wrap_optimal_fit(&words, &[15.0], &Penalties::new()).unwrap()),
+/// assert_eq!(lines_to_strings(wrap_optimal_fit(&words, &[15.0], 0, &Penalties::new()).unwrap()),
 ///            vec!["These few",
 ///                 "words will",
 ///                 "unfortunately",
@@ -284,7 +285,7 @@ impl Default for WrapAlgorithm {
 ///
 /// impl Fragment for Task<'_> {
 ///     fn width(&self) -> f64 { self.hours }
-///     fn whitespace_width(&self) -> f64 { self.sweep }
+///     fn whitespace_width(&self, tab_width: u8) -> f64 { self.sweep }
 ///     fn penalty_width(&self) -> f64 { self.cleanup }
 /// }
 ///
@@ -308,7 +309,7 @@ impl Default for WrapAlgorithm {
 ///     let mut days = Vec::new();
 ///     // Assign tasks to days. The assignment is a vector of slices,
 ///     // with a slice per day.
-///     let assigned_days: Vec<&[Task<'a>]> = wrap_first_fit(&tasks, &[day_length]);
+///     let assigned_days: Vec<&[Task<'a>]> = wrap_first_fit(&tasks, &[day_length], 0);
 ///     for day in assigned_days.iter() {
 ///         let last = day.last().unwrap();
 ///         let work_hours: f64 = day.iter().map(|t| t.hours + t.sweep).sum();
@@ -347,6 +348,7 @@ impl Default for WrapAlgorithm {
 pub fn wrap_first_fit<'a, T: Fragment>(
     fragments: &'a [T],
     line_widths: &[f64],
+    tab_width: u8,
 ) -> Vec<&'a [T]> {
     // The final line width is used for all remaining lines.
     let default_line_width = line_widths.last().copied().unwrap_or(0.0);
@@ -364,7 +366,7 @@ pub fn wrap_first_fit<'a, T: Fragment>(
             start = idx;
             width = 0.0;
         }
-        width += fragment.width() + fragment.whitespace_width();
+        width += fragment.width() + fragment.whitespace_width(tab_width);
     }
     lines.push(&fragments[start..]);
     lines
@@ -380,7 +382,7 @@ mod tests {
     #[rustfmt::skip]
     impl Fragment for Word {
         fn width(&self) -> f64 { self.0 }
-        fn whitespace_width(&self) -> f64 { 1.0 }
+        fn whitespace_width(&self, _: u8) -> f64 { 1.0 }
         fn penalty_width(&self) -> f64 { 0.0 }
     }
 
@@ -397,7 +399,7 @@ mod tests {
         // Wrap at just under f64::MAX (~19e307). The tiny
         // whitespace_widths disappear because of loss of precision.
         assert_eq!(
-            wrap_first_fit(&words, &[15e307]),
+            wrap_first_fit(&words, &[15e307], 0),
             &[
                 vec![
                     Word(1e307),


### PR DESCRIPTION
This merge request is an updated version of #429. It allows the width of a tab to be configured for a variety of this crate's functions, instead of the width being fixed at zero, as it currently is.