### PR TITLE
Avoid OOM in refill fuzz test

### DIFF
--- a/fuzz/fuzz_targets/refill.rs
+++ b/fuzz/fuzz_targets/refill.rs
@@ -6,5 +6,13 @@ fuzz_target!(|input: (String, usize)| {
         return; // Avoid timeouts in OSS-Fuzz.
     }
 
+    let (_, options) = textwrap::unfill(&input.0);
+    if options.subsequent_indent.len() > 10_000 {
+        // Avoid out of memory in OSS-fuzz. The indentation is added
+        // on every line of the output, meaning that is can make the
+        // memory usage explode.
+        return;
+    }
+
     let _ = textwrap::refill(&input.0, input.1);
 });


### PR DESCRIPTION
If two things happen at the same time:

1. the input string has a huge prefix which is taken to be the indentation (such as “- - - - -”), and
2. the wrapping with is set to something small (such as 0),

then we can end up allocating an enormous amount of data in the output. The problem is that we add the indentation on every line of the output, and we end up with a huge number of lines when the line width is small.

This was reported in OSS-Fuzz, please see
https://oss-fuzz.com/testcase-detail/4890847154143232.