### PR TITLE
Update GH Actions to use `$GITHUB_OUTPUT`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -208,9 +208,9 @@ jobs:
           git add --verbose --all
           if git diff --staged --quiet --exit-code; then
             echo "No changes found in textwrap-wasm-demo-app"
-            echo '::set-output name=has-changes::false'
+            echo 'has-changes=false' >> $GITHUB_OUTPUT
           else
-            echo '::set-output name=has-changes::true'
+            echo 'has-changes=true' >> $GITHUB_OUTPUT
           fi
 
       - name: Record build info

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -25,9 +25,9 @@ jobs:
           echo "Version from Cargo:  $OLD_VERSION"
           echo "Version from branch: $NEW_VERSION"
 
-          echo "::set-output name=name::$NAME"
-          echo "::set-output name=old-version::$OLD_VERSION"
-          echo "::set-output name=new-version::$NEW_VERSION"
+          echo "name=$NAME" >> $GITHUB_OUTPUT
+          echo "old-version=$OLD_VERSION" >> $GITHUB_OUTPUT
+          echo "new-version=$NEW_VERSION" >> $GITHUB_OUTPUT
 
       - name: Verify version format
         run: |

--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -23,9 +23,9 @@ jobs:
           VERSION=$(cargo metadata -q --no-deps | jq -r '.packages[0].version')
           CHANGELOG=$(awk '/^## Version/ {i++}; i==1 {print}; i>1 {exit}' CHANGELOG.md \
             | python3 -c 'import sys, json; print(json.dumps(sys.stdin.read()))')
-          echo "::set-output name=name::$NAME"
-          echo "::set-output name=version::$VERSION"
-          echo "::set-output name=changelog::$CHANGELOG"
+          echo "name=$NAME" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "changelog=$CHANGELOG" >> $GITHUB_OUTPUT
           echo "Found $NAME-$VERSION"
 
       - name: Lookup ${{ steps.vars.outputs.version }} tag


### PR DESCRIPTION
The old set-output command has been deprecated:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/.