### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ This is a major feature release with two main changes:
   instead of `usize` for fragment widths.
 
   This fixes problems with overflows in the internal computations of
-  `wrap_optimal_fit` when fragments (words) or line lenghts had
+  `wrap_optimal_fit` when fragments (words) or line lengths had
   extreme values, such as `usize::MAX`.
 
 * [#438](https://github.com/mgeisler/textwrap/pull/438): Simplify
@@ -135,7 +135,7 @@ let options: Options<
 > = Options::new(80);
 ```
 
-This is quite a mouthful, so we suggest using type inferrence where
+This is quite a mouthful, so we suggest using type inference where
 possible. You won’t see any chance if you call `wrap` directly with a
 width or with an `Options` value constructed on the fly. Please open
 an issue if this causes problems for you!
@@ -486,7 +486,7 @@ Added a regression test for the case where `width` is set to
 
 ## Version 0.8.0 (2017-09-04)
 
-The `Wrapper` stuct is now generic over the type of word splitter
+The `Wrapper` struct is now generic over the type of word splitter
 being used. This means less boxing and a nicer API. The
 `Wrapper::word_splitter` method has been removed. This is a *breaking
 API change* if you used the method to change the word splitter.

--- a/src/core.rs
+++ b/src/core.rs
@@ -117,7 +117,7 @@ fn ch_width(ch: char) -> usize {
 /// ## Emojis and CJK Characters
 ///
 /// Characters such as emojis and [CJK characters] used in the
-/// Chinese, Japanese, and Korean langauges are seen as double-width,
+/// Chinese, Japanese, and Korean languages are seen as double-width,
 /// even if the `unicode-width` feature is disabled:
 ///
 /// ```

--- a/src/word_splitters.rs
+++ b/src/word_splitters.rs
@@ -69,7 +69,7 @@ pub enum WordSplitter {
 
     /// Use a custom function as the word splitter.
     ///
-    /// This varian lets you implement a custom word splitter using
+    /// This variant lets you implement a custom word splitter using
     /// your own function.
     ///
     /// # Examples

--- a/src/wrap_algorithms.rs
+++ b/src/wrap_algorithms.rs
@@ -180,7 +180,7 @@ impl WrapAlgorithm {
 
             #[cfg(feature = "smawk")]
             WrapAlgorithm::OptimalFit(penalties) => {
-                // The computation cannnot overflow when the line
+                // The computation cannot overflow when the line
                 // widths are restricted to usize.
                 wrap_optimal_fit(words, &f64_line_widths, penalties).unwrap()
             }


### PR DESCRIPTION
Found via `typos --format brief`