### PR TITLE
Add unit test for uncovered regions

### DIFF
--- a/src/refill.rs
+++ b/src/refill.rs
@@ -224,10 +224,10 @@ mod tests {
     }
 
     #[test]
-    fn test_unfill_missing() {
-        let (text, options) = unfill("í\n*\n/");
-        assert_eq!(text, "í * /");
-        assert_eq!(options.width, 1);
+    fn test_unfill_consecutive_different_prefix() {
+        let (text, options) = unfill("foo\n*\n/");
+        assert_eq!(text, "foo * /");
+        assert_eq!(options.width, 3);
         assert_eq!(options.line_ending, LineEnding::LF);
     }
 

--- a/src/refill.rs
+++ b/src/refill.rs
@@ -224,6 +224,14 @@ mod tests {
     }
 
     #[test]
+    fn test_unfill_missing() {
+        let (text, options) = unfill("í\n*\n/");
+        assert_eq!(text, "í * /");
+        assert_eq!(options.width, 1);
+        assert_eq!(options.line_ending, LineEnding::LF);
+    }
+
+    #[test]
     fn unfill_trailing_newlines() {
         let (text, options) = unfill("foo\nbar\n\n\n");
         assert_eq!(text, "foo bar\n");


### PR DESCRIPTION
Hi,

Thanks for your time & patience to review this PR.

We are researchers focusing on Rust unit tests. By examine the existing code, we found a unit test can be added to improve the repo's overall unit test coverage(this project is already been well tested).
We only manually changed our assert statements to make it consistent with existing unit tests and the newly covered code region is:
https://github.com/mgeisler/textwrap/blob/872f221fede7aa78e730bb7895074455269a431a/src/refill.rs#L77-L80
Thanks again for reviewing.