### PR TITLE
Bump the minimum supported Rust version to 1.60

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56  # MSRV, Rust 2021
+          - '1.60'  # Current MSRV
           - stable
           - nightly
         features:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["text", "formatting", "wrap", "typesetting", "hyphenation"]
 categories = ["text-processing", "command-line-interface"]
 license = "MIT"
 edition = "2021"
+rust-version = "1.60"
 exclude = [".github/", ".gitignore", "benchmarks/", "examples/", "fuzz/", "images/"]
 
 [[example]]


### PR DESCRIPTION
The MSRV used to be 1.56 (the first Rust 2021 release), but a dependency updated its MSRV to 1.60. This a follow-up to #180.

This will fix the recent build errors in our weekly build.