### PR TITLE
Add `Options::width`

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -118,6 +118,13 @@ impl<'a> Options<'a> {
         }
     }
 
+    /// Set [`self.width`] to the given value.
+    ///
+    /// [`self.width`]: #structfield.width
+    pub fn width(self, width: usize) -> Self {
+        Options { width, ..self }
+    }
+
     /// Change [`self.initial_indent`]. The initial indentation is
     /// used on the very first line of output.
     ///


### PR DESCRIPTION
This is a convenience method to set the width of the `Options` struct. I found it useful to have builder-style access to this property, and it matches some of the other provided methods.