### PR TITLE
chore(cargo): Update `unicode-linebreak`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ default = ["unicode-linebreak", "unicode-width", "smawk"]
 hyphenation = { version = "0.8.4", optional = true, features = ["embed_en-us"] }
 smawk = { version = "0.3.1", optional = true }
 terminal_size = { version = "0.2.1", optional = true }
-unicode-linebreak = { version = "0.1.4", optional = true }
+unicode-linebreak = { version = "0.1.5", optional = true }
 unicode-width = { version = "0.1.10", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
`unicode-linebreak` 0.1.5 has been released. It removes the `build.rs` script (it's moved in another separate internal crate). Moving to 0.1.5 removes the following dependencies from the tree:

* `ahash`,
* `aho-corasick`,
* `hashbrown`,
* `once_cell`,
* `regex`,
* `regex-syntax`,
* `version_check`,
* `wasi`.

This isn't negligible.

Also, `ahash` was at version 0.7.6 (latest version is —at the time of writing— 0.8.8), which doesn't compile on Rust nightly. `ahash` was required by `hashbrown`, which was required as a build-dependency of `unicode-linebreak` 0.1.4. It's no longer the case in 0.1.5.