### PR TITLE
core: avoid spurious f64 cast and comparison

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -357,7 +357,7 @@ where
 {
     let mut shortened_words = Vec::new();
     for word in words {
-        if word.width() > line_width as f64 {
+        if word.width > line_width {
             shortened_words.extend(word.break_apart(line_width));
         } else {
             shortened_words.push(word);


### PR DESCRIPTION
This tweaks `break_words()` logic by dropping a cast to f64 and a float comparison, directly using the integer width value instead.