### PR TITLE
Update MSRV to 1.66 because of `unicode-width` dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["text", "formatting", "wrap", "typesetting", "hyphenation"]
 categories = ["text-processing", "command-line-interface"]
 license = "MIT"
 edition = "2021"
-rust-version = "1.62"
+rust-version = "1.66"
 exclude = [".github/", ".gitignore", "benchmarks/", "examples/", "fuzz/", "images/"]
 
 [[example]]


### PR DESCRIPTION
The `unicode-width` crate needs 1.66 because of using the `wrapping_add_signed` function.