### PR TITLE
Migrate coverage to llvm-cov

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,10 +22,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Run cargo-tarpaulin
-        uses: actions-rs/tarpaulin@v0.1
-        with:
-          args: '--${{ matrix.features }}'
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
 
-      - name: Upload to codecov.io
-        uses: codecov/codecov-action@v4
+      - name: Run tests with Coverage report enabled
+        run: cargo llvm-cov test --${{ matrix.features }} --codecov --locked --output-path codecov_report.json
+
+      - name: Upload coverage report to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./codecov_report.json


### PR DESCRIPTION
Tarpaulin seems no longer work, I see

> Couldn't find a release tarball containing binaries for latest

for the last many coverate runs.