### PR TITLE
Bump `rust-version` to 1.70

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["text", "formatting", "wrap", "typesetting", "hyphenation"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/mgeisler/textwrap"
-rust-version = "1.66"
+rust-version = "1.70"
 description = "Library for word wrapping, indenting, and dedenting strings. Has optional support for Unicode and emojis as well as machine hyphenation."
 
 [[example]]


### PR DESCRIPTION
This does two things: it fixes the warnings about the derived `Debug` implementation after #557. It also means that I don’t have to deal with the slow Git-based crates.io registry checkout when testing the old version.