### PR TITLE
Add a `CODECOV_TOKEN` repository secret

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,4 +31,5 @@ jobs:
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./codecov_report.json


### PR DESCRIPTION
This should finally enable code coverage reports for this project.