### PR TITLE
`Options`: Replace `&str` with `Cow`

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -1,5 +1,7 @@
 //! Options for wrapping text.
 
+use std::borrow::Cow;
+
 use crate::{LineEnding, WordSeparator, WordSplitter, WrapAlgorithm};
 
 /// Holds configuration options for wrapping and filling text.
@@ -12,10 +14,10 @@ pub struct Options<'a> {
     pub line_ending: LineEnding,
     /// Indentation used for the first line of output. See the
     /// [`Options::initial_indent`] method.
-    pub initial_indent: &'a str,
+    pub initial_indent: Cow<'a, str>,
     /// Indentation used for subsequent lines of output. See the
     /// [`Options::subsequent_indent`] method.
-    pub subsequent_indent: &'a str,
+    pub subsequent_indent: Cow<'a, str>,
     /// Allow long words to be broken if they cannot fit on a line.
     /// When set to `false`, some lines may be longer than
     /// `self.width`. See the [`Options::break_words`] method.
@@ -39,8 +41,8 @@ impl<'a> From<&'a Options<'a>> for Options<'a> {
         Self {
             width: options.width,
             line_ending: options.line_ending,
-            initial_indent: options.initial_indent,
-            subsequent_indent: options.subsequent_indent,
+            initial_indent: Cow::Borrowed(&options.initial_indent),
+            subsequent_indent: Cow::Borrowed(&options.subsequent_indent),
             break_words: options.break_words,
             word_separator: options.word_separator,
             wrap_algorithm: options.wrap_algorithm,
@@ -91,8 +93,8 @@ impl<'a> Options<'a> {
         Options {
             width,
             line_ending: LineEnding::LF,
-            initial_indent: "",
-            subsequent_indent: "",
+            initial_indent: Cow::Borrowed(""),
+            subsequent_indent: Cow::Borrowed(""),
             break_words: true,
             word_separator: WordSeparator::new(),
             wrap_algorithm: WrapAlgorithm::new(),
@@ -148,9 +150,12 @@ impl<'a> Options<'a> {
     /// ```
     ///
     /// [`self.initial_indent`]: #structfield.initial_indent
-    pub fn initial_indent(self, initial_indent: &'a str) -> Self {
+    pub fn initial_indent<T>(self, initial_indent: T) -> Self
+    where
+        Cow<'a, str>: From<T>,
+    {
         Options {
-            initial_indent,
+            initial_indent: initial_indent.into(),
             ..self
         }
     }
@@ -184,9 +189,12 @@ impl<'a> Options<'a> {
     /// ```
     ///
     /// [`self.subsequent_indent`]: #structfield.subsequent_indent
-    pub fn subsequent_indent(self, subsequent_indent: &'a str) -> Self {
+    pub fn subsequent_indent<T>(self, subsequent_indent: T) -> Self
+    where
+        Cow<'a, str>: From<T>,
+    {
         Options {
-            subsequent_indent,
+            subsequent_indent: subsequent_indent.into(),
             ..self
         }
     }

--- a/src/refill.rs
+++ b/src/refill.rs
@@ -1,5 +1,7 @@
 //! Functionality for unfilling and refilling text.
 
+use std::borrow::Cow;
+
 use crate::core::display_width;
 use crate::line_ending::NonEmptyLines;
 use crate::{fill, LineEnding, Options};
@@ -69,18 +71,18 @@ pub fn unfill(text: &str) -> (String, Options<'_>) {
         let prefix = &line[..line.len() - without_prefix.len()];
 
         if idx == 0 {
-            options.initial_indent = prefix;
+            options.initial_indent = Cow::Borrowed(prefix);
         } else if idx == 1 {
-            options.subsequent_indent = prefix;
+            options.subsequent_indent = Cow::Borrowed(prefix);
         } else if idx > 1 {
             for ((idx, x), y) in prefix.char_indices().zip(options.subsequent_indent.chars()) {
                 if x != y {
-                    options.subsequent_indent = &prefix[..idx];
+                    options.subsequent_indent = Cow::Borrowed(&prefix[..idx]);
                     break;
                 }
             }
             if prefix.len() < options.subsequent_indent.len() {
-                options.subsequent_indent = prefix;
+                options.subsequent_indent = Cow::Borrowed(prefix);
             }
         }
     }

--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -198,9 +198,9 @@ pub(crate) fn wrap_single_line<'a>(
     lines: &mut Vec<Cow<'a, str>>,
 ) {
     let indent = if lines.is_empty() {
-        options.initial_indent
+        &options.initial_indent
     } else {
-        options.subsequent_indent
+        &options.subsequent_indent
     };
     if line.len() < options.width && indent.is_empty() {
         if options.preserve_trailing_space {
@@ -223,10 +223,10 @@ pub(crate) fn wrap_single_line_slow_path<'a>(
 ) {
     let initial_width = options
         .width
-        .saturating_sub(display_width(options.initial_indent));
+        .saturating_sub(display_width(&options.initial_indent));
     let subsequent_width = options
         .width
-        .saturating_sub(display_width(options.subsequent_indent));
+        .saturating_sub(display_width(&options.subsequent_indent));
     let line_widths = [initial_width, subsequent_width];
 
     let words = options.word_separator.find_words(line);
@@ -270,9 +270,9 @@ pub(crate) fn wrap_single_line_slow_path<'a>(
         // The result is owned if we have indentation, otherwise we
         // can simply borrow an empty string.
         let mut result = if lines.is_empty() && !options.initial_indent.is_empty() {
-            Cow::Owned(options.initial_indent.to_owned())
+            Cow::Owned(options.initial_indent.clone().into_owned())
         } else if !lines.is_empty() && !options.subsequent_indent.is_empty() {
-            Cow::Owned(options.subsequent_indent.to_owned())
+            Cow::Owned(options.subsequent_indent.clone().into_owned())
         } else {
             // We can use an empty string here since string
             // concatenation for `Cow` preserves a borrowed value when


### PR DESCRIPTION
In [`tracing-human-layer`](https://docs.rs/tracing-human-layer/latest/tracing_human_layer/index.html), I would like users to be able to specify `textwrap::Options` ahead of time, but this is difficult because I can't hold an owned `Options` struct.

If we use a `Cow<'a, str>` instead of an `&'a str`, we'll be able to adapt existing use-cases while making it possible to construct a `textwrap::Options<'static>` with owned `String`s.

This is a breaking change.