### PR TITLE
Allow wrap to borrow when `preserve_trailing_space` is  `true`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,5 +232,4 @@ pub use termwidth::termwidth;
 pub use word_separators::WordSeparator;
 pub use word_splitters::WordSplitter;
 pub use wrap::wrap;
-pub use wrap::wrap_single_line;
 pub use wrap_algorithms::WrapAlgorithm;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,4 +232,5 @@ pub use termwidth::termwidth;
 pub use word_separators::WordSeparator;
 pub use word_splitters::WordSplitter;
 pub use wrap::wrap;
+pub use wrap::wrap_single_line;
 pub use wrap_algorithms::WrapAlgorithm;

--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -192,7 +192,7 @@ where
     lines
 }
 
-pub fn wrap_single_line<'a>(
+pub(crate) fn wrap_single_line<'a>(
     line: &'a str,
     options: &Options<'_>,
     lines: &mut Vec<Cow<'a, str>>,

--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -264,8 +264,7 @@ pub(crate) fn wrap_single_line_slow_path<'a>(
         let len = words
             .iter()
             .map(|word| word.len() + word.whitespace.len())
-            .sum::<usize>()
-            - last_word.whitespace.len();
+            .sum::<usize>();
 
         // The result is owned if we have indentation, otherwise we
         // can simply borrow an empty string.
@@ -280,12 +279,14 @@ pub(crate) fn wrap_single_line_slow_path<'a>(
             Cow::from("")
         };
 
-        result += &line[idx..idx + len];
+        if last_word.penalty.is_empty() && options.preserve_trailing_space {
+            result += &line[idx..idx + len];
+        } else {
+            result += &line[idx..idx + len - last_word.whitespace.len()];
+        }
 
         if !last_word.penalty.is_empty() {
             result.to_mut().push_str(last_word.penalty);
-        } else if options.preserve_trailing_space {
-            result.to_mut().push_str(last_word.whitespace);
         }
 
         lines.push(result);
@@ -293,7 +294,7 @@ pub(crate) fn wrap_single_line_slow_path<'a>(
         // Advance by the length of `result`, plus the length of
         // `last_word.whitespace` -- even if we had a penalty, we need
         // to skip over the whitespace.
-        idx += len + last_word.whitespace.len();
+        idx += len;
     }
 }
 

--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -192,7 +192,7 @@ where
     lines
 }
 
-pub(crate) fn wrap_single_line<'a>(
+pub fn wrap_single_line<'a>(
     line: &'a str,
     options: &Options<'_>,
     lines: &mut Vec<Cow<'a, str>>,

--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -699,6 +699,19 @@ mod tests {
     }
 
     #[test]
+    fn preserve_trailing_space_borrows_spaces() {
+        use std::borrow::Cow::Owned;
+        let lines = wrap(
+            "foo bar baz",
+            Options::new(10).preserve_trailing_space(true),
+        );
+        assert_eq!(lines, vec!["foo bar ", "baz"]);
+        if let Owned(ref s) = lines[0] {
+            assert!(false, "should not have been owned: {:?}", s);
+        }
+    }
+
+    #[test]
     fn wrap_colored_text() {
         // The words are much longer than 6 bytes, but they remain
         // intact after filling the text.


### PR DESCRIPTION
This pull request modifies `wrap_single_line_slow_path` to borrow when preserve_trailing_space is set and the final word has no penalty. Previously, it was unnecessarily forcing a copy in this case. I believe that logic remains exactly the same in all other cases.