### PR TITLE
Simplify by using `borrow()` instead of `borrow_mut()`

### DIFF
--- a/src/wrap_algorithms/optimal_fit.rs
+++ b/src/wrap_algorithms/optimal_fit.rs
@@ -171,7 +171,7 @@ impl LineNumbers {
     }
 
     fn get<T>(&self, i: usize, minima: &[(usize, T)]) -> usize {
-        while self.line_numbers.borrow_mut().len() < i + 1 {
+        while self.line_numbers.borrow().len() < i + 1 {
             let pos = self.line_numbers.borrow().len();
             let line_number = 1 + self.get(minima[pos].0, minima);
             self.line_numbers.borrow_mut().push(line_number);


### PR DESCRIPTION
since we're just reading the value and not modifying it, we don't need it to be mutable.