### PR TITLE
Update to `rustfmt` 2024 style edition

### DIFF
--- a/benchmarks/indent.rs
+++ b/benchmarks/indent.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 
 pub fn benchmark(c: &mut Criterion) {
     // Generate a piece of text with some empty lines.

--- a/benchmarks/linear.rs
+++ b/benchmarks/linear.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 
 // The benchmarks here verify that the complexity grows as O(*n*)
 // where *n* is the number of characters in the text to be wrapped.

--- a/benchmarks/unfill.rs
+++ b/benchmarks/unfill.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 
 pub fn benchmark(c: &mut Criterion) {
     let words_per_line = [

--- a/dprint.json
+++ b/dprint.json
@@ -4,7 +4,8 @@
   },
   "exec": {
     "commands": [{
-      "command": "rustfmt",
+      "setupCommand": "rustup toolchain install nightly-2026-06-25 --profile minimal --component rustfmt",
+      "command": "rustup run nightly-2026-06-25 rustfmt",
       "exts": ["rs"]
     }]
   },
@@ -13,7 +14,7 @@
     "https://plugins.dprint.dev/json-0.20.0.wasm",
     "https://plugins.dprint.dev/markdown-0.18.0.wasm",
     "https://plugins.dprint.dev/toml-0.7.0.wasm",
-    "https://plugins.dprint.dev/exec-0.5.1.json@492414e39dea4dccc07b4af796d2f4efdb89e84bae2bd4e1e924c0cc050855bf",
+    "https://plugins.dprint.dev/exec-0.7.2.json@6c30bd00dfb176774ece412d0fbf149478269ecc92c55ab2d6f4116938ed993e",
     "https://plugins.dprint.dev/prettier-0.57.0.json@1bc6b449e982d5b91a25a7c59894102d40c5748651a08a095fb3926e64d55a31"
   ]
 }

--- a/examples/interactive.rs
+++ b/examples/interactive.rs
@@ -19,7 +19,7 @@ mod unix_only {
     use termion::raw::{IntoRawMode, RawTerminal};
     use termion::screen::IntoAlternateScreen;
     use termion::{color, cursor, style};
-    use textwrap::{wrap, Options, WordSeparator, WordSplitter, WrapAlgorithm};
+    use textwrap::{Options, WordSeparator, WordSplitter, WrapAlgorithm, wrap};
 
     #[cfg(feature = "hyphenation")]
     use hyphenation::{Language, Load, Standard};

--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -1,4 +1,4 @@
-use textwrap::{wrap, Options, WordSplitter};
+use textwrap::{Options, WordSplitter, wrap};
 
 fn main() {
     let example = "Memory safety without garbage collection. \

--- a/examples/termwidth.rs
+++ b/examples/termwidth.rs
@@ -1,4 +1,4 @@
-use textwrap::{fill, Options, WordSplitter};
+use textwrap::{Options, WordSplitter, fill};
 
 fn main() {
     let example = "Memory safety without garbage collection. \

--- a/examples/wasm/src/lib.rs
+++ b/examples/wasm/src/lib.rs
@@ -1,9 +1,9 @@
 use unicode_segmentation::UnicodeSegmentation;
-use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
+use wasm_bindgen::prelude::*;
 
 use textwrap::word_splitters::split_words;
-use textwrap::wrap_algorithms::{wrap_first_fit, wrap_optimal_fit, Penalties};
+use textwrap::wrap_algorithms::{Penalties, wrap_first_fit, wrap_optimal_fit};
 use textwrap::{WordSeparator, WordSplitter};
 
 #[wasm_bindgen]

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,3 @@
+edition = "2024"
+# Use rustfmt from the nightly channel for this:
 imports_granularity = "Module"

--- a/src/columns.rs
+++ b/src/columns.rs
@@ -1,7 +1,7 @@
 //! Functionality for wrapping text into columns.
 
 use crate::core::display_width;
-use crate::{wrap, Options};
+use crate::{Options, wrap};
 
 /// Wrap text into columns with a given total width.
 ///

--- a/src/core.rs
+++ b/src/core.rs
@@ -96,11 +96,7 @@ const DOUBLE_WIDTH_CUTOFF: char = '\u{1100}';
 #[cfg(not(feature = "unicode-width"))]
 #[inline]
 fn ch_width(ch: char) -> usize {
-    if ch < DOUBLE_WIDTH_CUTOFF {
-        1
-    } else {
-        2
-    }
+    if ch < DOUBLE_WIDTH_CUTOFF { 1 } else { 2 }
 }
 
 /// Compute the display width of `text` while skipping over ANSI

--- a/src/fill.rs
+++ b/src/fill.rs
@@ -1,6 +1,6 @@
 //! Functions for filling text.
 
-use crate::{wrap, wrap_algorithms, Options, WordSeparator};
+use crate::{Options, WordSeparator, wrap, wrap_algorithms};
 
 /// Fill a line of text at a given width.
 ///

--- a/src/refill.rs
+++ b/src/refill.rs
@@ -2,7 +2,7 @@
 
 use crate::core::display_width;
 use crate::line_ending::NonEmptyLines;
-use crate::{fill, LineEnding, Options};
+use crate::{LineEnding, Options, fill};
 
 /// Unpack a paragraph of already-wrapped text.
 ///

--- a/src/word_separators.rs
+++ b/src/word_separators.rs
@@ -14,9 +14,9 @@
 //! there words are in a line of text. Please refer to the enum and
 //! its variants for more information.
 
+use crate::core::Word;
 #[cfg(feature = "unicode-linebreak")]
 use crate::core::skip_ansi_escape_sequence;
-use crate::core::Word;
 
 #[cfg(feature = "unicode-linebreak")]
 thread_local! {

--- a/src/word_splitters.rs
+++ b/src/word_splitters.rs
@@ -4,7 +4,7 @@
 //! across lines. The [`WordSplitter`] enum defines this
 //! functionality.
 
-use crate::core::{display_width, Word};
+use crate::core::{Word, display_width};
 
 /// The `WordSplitter` enum describes where words can be split.
 ///

--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -2,9 +2,9 @@
 
 use std::borrow::Cow;
 
-use crate::core::{break_words, display_width, Word};
-use crate::word_splitters::split_words;
 use crate::Options;
+use crate::core::{Word, break_words, display_width};
+use crate::word_splitters::split_words;
 
 /// Wrap a line of text at a given width.
 ///

--- a/src/wrap_algorithms.rs
+++ b/src/wrap_algorithms.rs
@@ -20,7 +20,7 @@
 #[cfg(feature = "smawk")]
 mod optimal_fit;
 #[cfg(feature = "smawk")]
-pub use optimal_fit::{wrap_optimal_fit, OverflowError, Penalties};
+pub use optimal_fit::{OverflowError, Penalties, wrap_optimal_fit};
 
 use crate::core::{Fragment, Word};
 


### PR DESCRIPTION
With https://github.com/dprint/dprint/issues/1023 closed, we can now control the `rustfmt` version as part of the `dprint` configuration.