### PR TITLE
Update references to the old `master` branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
   schedule:
     - cron: "30 17 * * 5" # Every Friday at 17:30 UTC
 
@@ -220,7 +220,7 @@ jobs:
   wasm-deploy:
     name: Deploy Wasm demo
     needs: wasm-build
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,7 +3,7 @@ name: coverage
 on:
   push:
     branches:
-      - master
+      - main
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -187,7 +187,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               head: 'release-${{ needs.setup.outputs.new-version }}',
-              base: 'master',
+              base: 'main',
               title: 'Release ${{ needs.setup.outputs.new-version }}',
               body: process.env.CHANGELOG,
             })

--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -3,7 +3,7 @@ name: Publish Crate
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - Cargo.toml
   repository_dispatch:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Textwrap
 
 [![](https://github.com/mgeisler/textwrap/workflows/build/badge.svg)][build-status]
-[![](https://codecov.io/gh/mgeisler/textwrap/branch/master/graph/badge.svg)][codecov]
+[![](https://codecov.io/gh/mgeisler/textwrap/branch/main/graph/badge.svg)][codecov]
 [![](https://img.shields.io/crates/v/textwrap.svg)][crates-io]
 [![](https://docs.rs/textwrap/badge.svg)][api-docs]
 
@@ -124,8 +124,8 @@ macros from the [`textwrap-macros` crate].
 ## Examples
 
 The library comes with
-[a collection](https://github.com/mgeisler/textwrap/tree/master/examples) of
-small example programs that shows various features.
+[a collection](https://github.com/mgeisler/textwrap/tree/main/examples) of small
+example programs that shows various features.
 
 If you want to see Textwrap in action right away, then take a look at
 [`examples/wasm/`], which shows how to wrap sans-serif, serif, and monospace
@@ -157,18 +157,18 @@ Textwrap can be distributed according to the [MIT license][mit]. Contributions
 will be accepted under the same license.
 
 [crates-io]: https://crates.io/crates/textwrap
-[build-status]: https://github.com/mgeisler/textwrap/actions?query=workflow%3Abuild+branch%3Amaster
+[build-status]: https://github.com/mgeisler/textwrap/actions?query=workflow%3Abuild+branch%3Amain
 [codecov]: https://codecov.io/gh/mgeisler/textwrap
 [wasm-demo]: https://mgeisler.github.io/textwrap/
 [`textwrap-macros` crate]: https://crates.io/crates/textwrap-macros
-[`hyphenation` example]: https://github.com/mgeisler/textwrap/blob/master/examples/hyphenation.rs
-[`termwidth` example]: https://github.com/mgeisler/textwrap/blob/master/examples/termwidth.rs
+[`hyphenation` example]: https://github.com/mgeisler/textwrap/blob/main/examples/hyphenation.rs
+[`termwidth` example]: https://github.com/mgeisler/textwrap/blob/main/examples/termwidth.rs
 [patterns]: https://github.com/tapeinosyne/hyphenation/tree/master/patterns
 [en-us license]: https://github.com/hyphenation/tex-hyphen/blob/master/hyph-utf8/tex/generic/hyph-utf8/patterns/tex/hyph-en-us.tex
 [bincode]: https://github.com/tapeinosyne/hyphenation/tree/master/dictionaries
 [`hyphenation` documentation]: http://docs.rs/hyphenation
-[`examples/wasm/`]: https://github.com/mgeisler/textwrap/tree/master/examples/wasm
-[`examples/interactive.rs`]: https://github.com/mgeisler/textwrap/tree/master/examples/interactive.rs
+[`examples/wasm/`]: https://github.com/mgeisler/textwrap/tree/main/examples/wasm
+[`examples/interactive.rs`]: https://github.com/mgeisler/textwrap/tree/main/examples/interactive.rs
 [api-docs]: https://docs.rs/textwrap/
-[CHANGELOG file]: https://github.com/mgeisler/textwrap/blob/master/CHANGELOG.md
+[CHANGELOG file]: https://github.com/mgeisler/textwrap/blob/main/CHANGELOG.md
 [mit]: LICENSE

--- a/examples/wasm/README.md
+++ b/examples/wasm/README.md
@@ -9,15 +9,15 @@ the pixel width of each word as it is rendered to the canvas.
 - **Live demo:
   [mgeisler.github.io/textwrap/](https://mgeisler.github.io/textwrap/).** Here
   you can try the demo. It is automatically deployed on every merge to the
-  `master` branch.
+  `main` branch.
 
 - **Source code:
-  [`examples/wasm/`](https://github.com/mgeisler/textwrap/tree/master/examples/wasm).**
+  [`examples/wasm/`](https://github.com/mgeisler/textwrap/tree/main/examples/wasm).**
   This is the Rust code which make up the demo. You will also find some
   JavaScript and HTML glue code.
 
 - **GitHub Action:
-  [`build.yml`](https://github.com/mgeisler/textwrap/blob/master/.github/workflows/build.yml).**
+  [`build.yml`](https://github.com/mgeisler/textwrap/blob/main/.github/workflows/build.yml).**
   This is the script which compiles and deploys the code. We use
   [`wasm-pack`](https://github.com/rustwasm/wasm-pack) to easily compile
   Textwrap and its dependencies to Wasm.

--- a/src/fill.rs
+++ b/src/fill.rs
@@ -115,7 +115,7 @@ pub(crate) fn fill_slow_path(text: &str, options: Options<'_>) -> String {
 ///
 /// In benchmarks, `fill_inplace` is about twice as fast as
 /// [`fill()`]. Please see the [`linear`
-/// benchmark](https://github.com/mgeisler/textwrap/blob/master/benchmarks/linear.rs)
+/// benchmark](https://github.com/mgeisler/textwrap/blob/main/benchmarks/linear.rs)
 /// for details.
 pub fn fill_inplace(text: &mut String, width: usize) {
     let mut indices = Vec::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,7 +113,7 @@
 //! The full dependency graph, where dashed lines indicate optional
 //! dependencies, is shown below:
 //!
-//! <img src="https://raw.githubusercontent.com/mgeisler/textwrap/master/images/textwrap-0.16.2.svg">
+//! <img src="https://raw.githubusercontent.com/mgeisler/textwrap/main/images/textwrap-0.16.2.svg">
 //!
 //! ## Default Features
 //!
@@ -188,7 +188,7 @@
 //! [icu_segmenter]: https://docs.rs/icu_segmenter/
 //! [unicode-width]: https://docs.rs/unicode-width/
 //! [smawk]: https://docs.rs/smawk/
-//! [binary-sizes demo]: https://github.com/mgeisler/textwrap/tree/master/examples/binary-sizes
+//! [binary-sizes demo]: https://github.com/mgeisler/textwrap/tree/main/examples/binary-sizes
 //! [textwrap-macros]: https://docs.rs/textwrap-macros/
 //! [terminal_size]: https://docs.rs/terminal_size/
 //! [hyphenation]: https://docs.rs/hyphenation/

--- a/tests/version-numbers.rs
+++ b/tests/version-numbers.rs
@@ -18,5 +18,5 @@ fn test_html_root_url() {
 
 #[test]
 fn test_dependency_graph() {
-    version_sync::assert_contains_regex!("src/lib.rs", "master/images/textwrap-{version}.svg");
+    version_sync::assert_contains_regex!("src/lib.rs", "main/images/textwrap-{version}.svg");
 }


### PR DESCRIPTION
The branch has been renamed to `main`, but there were many left-over references in the code and in build scripts.