### PR TITLE
Avoid arithmetic overflow in wrap_columns

### DIFF
--- a/src/columns.rs
+++ b/src/columns.rs
@@ -75,11 +75,7 @@ where
 
     let mut options: Options = total_width_or_options.into();
 
-    let inner_width = options
-        .width
-        .saturating_sub(display_width(left_gap))
-        .saturating_sub(display_width(right_gap))
-        .saturating_sub(display_width(middle_gap) * (columns - 1));
+    let inner_width = inner_width(options.width, columns, left_gap, middle_gap, right_gap);
 
     let column_width = std::cmp::max(inner_width / columns, 1);
     options.width = column_width;
@@ -111,6 +107,26 @@ where
     }
 
     lines
+}
+
+/// Compute the width left for the columns themselves, i.e., the total
+/// width minus the width of the gaps.
+///
+/// The multiplication is saturating because `columns` is unbounded and
+/// the combined width of the middle gaps can thus exceed `usize::MAX`.
+/// Nothing is lost by saturating: such a product is larger than
+/// `width`, so the subtraction saturates to zero either way.
+fn inner_width(
+    width: usize,
+    columns: usize,
+    left_gap: &str,
+    middle_gap: &str,
+    right_gap: &str,
+) -> usize {
+    width
+        .saturating_sub(display_width(left_gap))
+        .saturating_sub(display_width(right_gap))
+        .saturating_sub(display_width(middle_gap).saturating_mul(columns - 1))
 }
 
 #[cfg(test)]
@@ -189,5 +205,20 @@ mod tests {
     #[should_panic]
     fn wrap_columns_panic_with_zero_columns() {
         wrap_columns("", 0, 10, "", "", "");
+    }
+
+    #[test]
+    fn inner_width_with_normal_gaps() {
+        // The gaps take up a total of 5 columns.
+        assert_eq!(inner_width(21, 4, "|", "|", "|"), 16);
+    }
+
+    #[test]
+    fn inner_width_with_huge_number_of_columns() {
+        // The combined width of the middle gaps overflows a `usize`,
+        // which leaves no room at all for the columns. The number of
+        // columns is chosen so that a wrapping multiplication would
+        // wrap all the way around to zero.
+        assert_eq!(inner_width(80, usize::MAX / 2 + 2, "", "xx", ""), 0);
     }
 }


### PR DESCRIPTION
Fixes #517.

## The bug

`wrap_columns` computes the combined width of the middle gaps with a plain multiplication:

```rust
.saturating_sub(display_width(middle_gap) * (columns - 1));
```

Everything else in that chain is saturating, but this multiplication is not, so a large `columns` value overflows it:

```rust
textwrap::wrap_columns("hello world", usize::MAX, 80, "", "xx", "");
```

```
thread 'main' panicked at src/columns.rs:82:25:
attempt to multiply with overflow
```

That contradicts the function's own documentation, which says it panics only when `columns` is zero. In a release build there is no panic, but the multiplication wraps around and `inner_width` becomes an arbitrary number instead of zero.

This is the fuzzing crash @HeeillWang reported in #517; you said you would be happy to take a PR for it.

## The fix

Make the multiplication saturating, matching the `saturating_sub` calls around it. Saturating loses no information here: if the product does not fit in a `usize`, it is necessarily larger than `options.width`, so the subtraction saturates to zero either way. Every input that does not overflow today keeps exactly the same result.

I picked saturating over an `assert!` or an early return because it is what the surrounding code already does and because it needs no new documented panic condition. If you would rather reject an unreasonable `columns` value outright with an `assert!`, say the word and I will switch it — the change is small either way.

I also moved the width computation into a small private `inner_width` helper. That is needed to test the fix at all: any `columns` value large enough to overflow the multiplication is also large enough that `wrap_columns` would spend the rest of the day building a line with that many columns, so the overflow cannot be exercised through the public function.

## Verification

New test in `src/columns.rs`. Before the fix, in debug:

```
---- columns::tests::inner_width_with_huge_number_of_columns stdout ----
thread 'columns::tests::inner_width_with_huge_number_of_columns' panicked at src/columns.rs:130:25:
attempt to multiply with overflow

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 150 filtered out
```

Before the fix, in release, where the wraparound is silent — the number of columns in the test is chosen so that the wrapping product comes out as zero, which makes the test catch the wrong value and not just the panic:

```
---- columns::tests::inner_width_with_huge_number_of_columns stdout ----
assertion `left == right` failed
  left: 80
 right: 0

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 150 filtered out
```

After the fix both pass. Full suite with `cargo test`, `cargo test --all-features` and `cargo test --no-default-features` is green (151/156/134 unit tests plus the doc tests), and `dprint`'s rustfmt is happy.

## Not changed

* The example in the doc comment still spells the computation with `-` and `*`. It was already a simplification of the saturating version, so I left it as prose rather than mirroring the saturating calls into it.
* `wrap_columns` is inherently O(`columns`) — it always emits `columns` columns — so an absurd `columns` value still asks for an absurdly large output. That is already true today for an empty `middle_gap`, which never overflows, so it is independent of this bug; it looks like the same class of thing as the memory-usage note in `fuzz/fuzz_targets/refill.rs`. Happy to look at bounding it separately if you think it is worth guarding.
