### PR TITLE
Reduce MSRV to 1.88

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["text", "formatting", "wrap", "typesetting", "hyphenation"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/mgeisler/textwrap"
-rust-version = "1.90"
+rust-version = "1.88"
 description = "Library for word wrapping, indenting, and dedenting strings. Has optional support for Unicode and emojis as well as machine hyphenation."
 
 [[example]]


### PR DESCRIPTION
MSRV was bumped to 1.90 in https://github.com/mgeisler/textwrap/pull/610, with the justification that this was required by `icu_segmenter` 2.3.0. However, `icu_segmenter` 2.3.0 actually only requires Rust 1.88, so the MSRV can be reduced accordingly.