### PR TITLE
Remove deprecated package authors field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "textwrap"
 version = "0.16.3"
-authors = ["Martin Geisler <martin@geisler.net>"]
 categories = ["text-processing", "command-line-interface"]
 documentation = "https://docs.rs/textwrap/"
 edition = "2021"

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "textwrap-benchmarks"
 version = "0.1.0"
-authors = ["Martin Geisler <martin@geisler.net>"]
 edition = "2021"
 license-file = "../LICENSE"
 publish = false # This should not be uploaded to crates.io

--- a/examples/binary-sizes/Cargo.toml
+++ b/examples/binary-sizes/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "textwrap-binary-sizes-demo"
 version = "0.1.0"
-authors = ["Martin Geisler <martin@geisler.net>"]
 edition = "2021"
 license-file = "../../LICENSE"
 publish = false # This demo project should not be uploaded to crates.io

--- a/examples/wasm/Cargo.toml
+++ b/examples/wasm/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "textwrap-wasm-demo"
 version = "0.1.0"
-authors = ["Martin Geisler <martin@geisler.net>"]
 edition = "2021"
 license = "MIT"
 publish = false # This project should not be uploaded to crates.io

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "textwrap-fuzz"
 version = "0.0.0"
-authors = ["Automatically generated"]
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
`package.authors` is deprecated: https://github.com/rust-lang/cargo/pull/15068