### PR TITLE
Update benchmark dependencies to criterion 0.8 and lipsum 0.9

### DIFF
--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -12,21 +12,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
+name = "anstyle"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "autocfg"
@@ -44,12 +48,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -60,6 +58,16 @@ name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "cc"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "005ec2760ca554fae18df7a11195552ec576cd665632a881bc011d5bb2fd4d80"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -96,46 +104,49 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.25"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
- "bitflags",
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
+dependencies = [
+ "anstyle",
  "clap_lex",
- "indexmap",
- "textwrap 0.16.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
-]
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "criterion"
-version = "0.4.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c76e09c1aae2bc52b3d2f29e13c6572553b30c4aa1b8a49fd70de6412654cb"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
 dependencies = [
+ "alloca",
  "anes",
- "atty",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
  "itertools",
- "lazy_static",
  "num-traits",
  "oorandom",
+ "page_size",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
@@ -143,9 +154,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.5.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
  "itertools",
@@ -200,6 +211,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e0f1c7c3a72c66fd80abe965175f7523475c0489a87d3ff9d6e8c87d87a9d2d"
+
+[[package]]
 name = "fst"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -225,21 +242,6 @@ dependencies = [
  "cfg-if",
  "crunchy",
  "zerocopy",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -353,20 +355,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae293c039020f9ec10710af98d29ce6aa2051486638b49c9a6409f3b4a9e98ad"
 
 [[package]]
-name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown",
-]
-
-[[package]]
 name = "itertools"
-version = "0.10.5"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -388,12 +380,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
 name = "libc"
 version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -401,9 +387,9 @@ checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "lipsum"
-version = "0.8.2"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8451846f1f337e44486666989fbce40be804da139d5a4477d6b88ece5dc69f4"
+checksum = "636860251af8963cc40f6b4baadee105f02e21b28131d76eba8e40ce84ab8064"
 dependencies = [
  "rand",
  "rand_chacha",
@@ -443,10 +429,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
-name = "os_str_bytes"
-version = "6.6.1"
+name = "page_size"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "plotters"
@@ -658,6 +648,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "smallvec"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -710,7 +706,7 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.16.2"
+version = "0.16.3"
 dependencies = [
  "hyphenation",
  "icu_segmenter",
@@ -719,19 +715,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
-
-[[package]]
 name = "textwrap-benchmarks"
 version = "0.1.0"
 dependencies = [
  "criterion",
  "hyphenation",
  "lipsum",
- "textwrap 0.16.2",
+ "rand",
+ "rand_chacha",
+ "textwrap",
 ]
 
 [[package]]

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -26,6 +26,8 @@ path = "unfill.rs"
 textwrap = { path = "../", features = ["hyphenation"] }
 
 [dev-dependencies]
-criterion = "0.4.0"
+criterion = "0.8.2"
 hyphenation = { version = "0.8.4", features = ["embed_en-us"] }
-lipsum = "0.8.0"
+lipsum = "0.9.1"
+rand = "0.8"
+rand_chacha = "0.3"

--- a/benchmarks/indent.rs
+++ b/benchmarks/indent.rs
@@ -1,4 +1,7 @@
 use criterion::{Criterion, criterion_group, criterion_main};
+use lipsum::lipsum_words_with_rng;
+use rand::SeedableRng;
+use rand_chacha::ChaCha20Rng;
 
 pub fn benchmark(c: &mut Criterion) {
     // Generate a piece of text with some empty lines.
@@ -11,7 +14,8 @@ pub fn benchmark(c: &mut Criterion) {
     ];
     let mut text = String::new();
     for (line_no, word_count) in words_per_line.iter().enumerate() {
-        text.push_str(&lipsum::lipsum_words_from_seed(*word_count, line_no as u64));
+        let rng = ChaCha20Rng::seed_from_u64(line_no as u64);
+        text.push_str(&lipsum_words_with_rng(rng, *word_count));
         text.push('\n');
     }
     assert_eq!(text.len(), 2304); // The size for reference.

--- a/benchmarks/linear.rs
+++ b/benchmarks/linear.rs
@@ -5,7 +5,9 @@ use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 // The benchmarks here verify that the complexity grows as O(*n*)
 // where *n* is the number of characters in the text to be wrapped.
 
-use lipsum::lipsum_words_from_seed;
+use lipsum::lipsum_words_with_rng;
+use rand::SeedableRng;
+use rand_chacha::ChaCha20Rng;
 
 const LINE_LENGTH: usize = 60;
 
@@ -14,7 +16,8 @@ fn lorem_ipsum(length: usize) -> String {
     // The average word length in the lorem ipsum text is somewhere
     // between 6 and 7. So we conservatively divide by 5 to have a
     // long enough text that we can truncate below.
-    let mut text = lipsum_words_from_seed(length / 5, 42);
+    let rng = ChaCha20Rng::seed_from_u64(42);
+    let mut text = lipsum_words_with_rng(rng, length / 5);
     text.truncate(length);
     text
 }

--- a/benchmarks/unfill.rs
+++ b/benchmarks/unfill.rs
@@ -1,4 +1,7 @@
 use criterion::{Criterion, criterion_group, criterion_main};
+use lipsum::lipsum_words_with_rng;
+use rand::SeedableRng;
+use rand_chacha::ChaCha20Rng;
 
 pub fn benchmark(c: &mut Criterion) {
     let words_per_line = [
@@ -10,7 +13,8 @@ pub fn benchmark(c: &mut Criterion) {
     ];
     let mut text = String::new();
     for (line_no, word_count) in words_per_line.iter().enumerate() {
-        text.push_str(&lipsum::lipsum_words_from_seed(*word_count, line_no as u64));
+        let rng = ChaCha20Rng::seed_from_u64(line_no as u64);
+        text.push_str(&lipsum_words_with_rng(rng, *word_count));
         text.push('\n');
     }
     text.push_str("\n\n\n\n");


### PR DESCRIPTION
This updates the dependencies in `benchmarks/Cargo.toml` to their latest versions:

- `criterion`: 0.4.0 -> 0.8.2
- `lipsum`: 0.8.0 -> 0.9.1

The benchmarks in `benchmarks/linear.rs`, `benchmarks/indent.rs`, and `benchmarks/unfill.rs` are adapted to use `lipsum::lipsum_words_with_rng` with a seeded `ChaCha20Rng`, preserving deterministic text generation and passing all length assertions.